### PR TITLE
Change state handler obj

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(rosidl_typesupport_cpp REQUIRED)
 add_library(rclcpp_lifecycle
   src/lifecycle_node.cpp
   src/lifecycle_node_interface_impl.cpp
+  src/change_state_handler_impl.cpp
   src/managed_entity.cpp
   src/node_interfaces/lifecycle_node_interface.cpp
   src/state.cpp

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
@@ -1,0 +1,38 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_
+#define RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_
+
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+namespace rclcpp_lifecycle
+{
+class ChangeStateHandler
+{
+public:
+  /// Continues the change state process handling proper callback order
+  /** Used within the user defined transition callback to continue the change state process
+   *  similar to a service call response
+   *  Also used within the lifecycle_node_interface_impl to continue the change state process
+   * \param[in] cb_return_code result of user defined transition callback
+   */
+  virtual void continue_change_state(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) = 0;
+
+  virtual ~ChangeStateHandler() {}
+};
+}  // namespace rclcpp_lifecycle
+
+#endif  // RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
@@ -28,7 +28,7 @@ public:
    *  Also used within the lifecycle_node_interface_impl to continue the change state process
    * \param[in] cb_return_code result of user defined transition callback
    */
-  virtual void continue_change_state(
+  virtual void send_callback_resp(
     node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) = 0;
 
   virtual ~ChangeStateHandler() {}

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -90,6 +90,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/transition.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
+#include "change_state_handler.hpp"
 
 namespace rclcpp_lifecycle
 {
@@ -1004,7 +1005,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_configure(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_configure(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the configure async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_configure(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the cleanup callback
   /**
@@ -1014,7 +1027,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_cleanup(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_cleanup(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the cleanup async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_cleanup(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the shutdown callback
   /**
@@ -1024,7 +1049,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_shutdown(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_shutdown(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the shutdown async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_shutdown(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the activate callback
   /**
@@ -1034,7 +1071,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_activate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_activate(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the activate async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_activate(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the deactivate callback
   /**
@@ -1044,7 +1093,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_deactivate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_deactivate(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the deactivate async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_deactivate(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the error callback
   /**
@@ -1054,7 +1115,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_error(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_error(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the error async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_error(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   CallbackReturn

--- a/rclcpp_lifecycle/src/change_state_handler_impl.cpp
+++ b/rclcpp_lifecycle/src/change_state_handler_impl.cpp
@@ -1,0 +1,332 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "change_state_handler_impl.hpp"
+#include <cassert>
+#include <memory>
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rcl_lifecycle/rcl_lifecycle.h"
+
+namespace rclcpp_lifecycle
+{
+ChangeStateHandlerImpl::ChangeStateHandlerImpl(
+  std::recursive_mutex & state_machine_mutex,
+  rcl_lifecycle_state_machine_t & state_machine,
+  State & current_state,
+  const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface)
+: state_machine_mutex_(state_machine_mutex),
+  state_machine_(state_machine),
+  current_state_(current_state),
+  node_base_interface_(node_base_interface)
+{
+}
+
+void
+ChangeStateHandlerImpl::set_change_state_srv_hdl(
+  const std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl)
+{
+  assert(change_state_srv_hdl_ == nullptr);
+  change_state_srv_hdl_ = change_state_srv_hdl;
+}
+
+bool
+ChangeStateHandlerImpl::register_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
+{
+  cb_map_[lifecycle_transition] = cb;
+  auto it = async_cb_map_.find(lifecycle_transition);
+  if (it != async_cb_map_.end()) {
+    async_cb_map_.erase(it);
+  }
+  return true;
+}
+
+bool
+ChangeStateHandlerImpl::register_async_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb)
+{
+  async_cb_map_[lifecycle_transition] = cb;
+  auto it = cb_map_.find(lifecycle_transition);
+  if (it != cb_map_.end()) {
+    cb_map_.erase(it);
+  }
+  return true;
+}
+
+void
+ChangeStateHandlerImpl::continue_change_state(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  unsigned int current_state_id;
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    current_state_id = state_machine_.current_state->id;
+  }
+
+  if (current_state_id ==
+    lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING)
+  {
+    post_on_error_change_state(cb_return_code);
+  } else if (!utf_has_been_called_.load()) {
+    utf_has_been_called_.store(true);
+    post_utf_change_state(cb_return_code);
+  } else {
+    RCUTILS_LOG_ERROR(
+      "continue_change_state failed: called too many times");
+    rcl_ret_error();
+  }
+}
+
+void
+ChangeStateHandlerImpl::change_state(
+  uint8_t transition_id,
+  const std::shared_ptr<rmw_request_id_t> header)
+{
+  assert(change_state_srv_hdl_ != nullptr);
+  if (is_transitioning()) {
+    RCUTILS_LOG_ERROR(
+      "Currently in transition, failing requested transition id %d.", transition_id);
+    if (header) {
+      ChangeStateSrv::Response resp;
+      resp.success = false;
+      change_state_srv_hdl_->send_response(*header, resp);
+    }
+    return;
+  }
+
+  is_transitioning_.store(true);
+  utf_has_been_called_.store(false);
+  header_ = header;
+  transition_id_ = transition_id;
+
+  unsigned int current_state_id;
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    constexpr bool publish_update = true;
+    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR(
+        "Unable to change state for state machine for %s: %s",
+        node_base_interface_->get_name(), rcl_get_error_string().str);
+      rcl_ret_error();
+      return;
+    }
+
+    pre_transition_primary_state_ = State(state_machine_.current_state);
+
+    if (
+      rcl_lifecycle_trigger_transition_by_id(
+        &state_machine_, transition_id_, publish_update) != RCL_RET_OK)
+    {
+      RCUTILS_LOG_ERROR(
+        "Unable to start transition %u from current state %s: %s",
+        transition_id_, state_machine_.current_state->label,
+        rcl_get_error_string().str);
+      rcutils_reset_error();
+      rcl_ret_error();
+      return;
+    }
+    current_state_id = state_machine_.current_state->id;
+    // Update the internal current_state_
+    current_state_ = State(state_machine_.current_state);
+  }
+
+  if (is_async_callback(current_state_id)) {
+    execute_async_callback(current_state_id, pre_transition_primary_state_);
+  } else {
+    cb_return_code_ = execute_callback(
+      current_state_id,
+      pre_transition_primary_state_);
+    continue_change_state(cb_return_code_);
+  }
+}
+
+void
+ChangeStateHandlerImpl::post_utf_change_state(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  constexpr bool publish_update = true;
+  unsigned int current_state_id;
+
+  cb_return_code_ = cb_return_code;
+  auto transition_label = get_label_for_return_code(cb_return_code);
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    if (
+      rcl_lifecycle_trigger_transition_by_label(
+        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
+    {
+      RCUTILS_LOG_ERROR(
+        "Failed to finish transition %u: Current state is now: %s (%s)",
+        transition_id_,
+        state_machine_.current_state->label,
+        rcl_get_error_string().str);
+      rcutils_reset_error();
+      rcl_ret_error();
+      return;
+    }
+    current_state_id = state_machine_.current_state->id;
+
+    // Update the internal current_state_
+    current_state_ = State(state_machine_.current_state);
+  }
+
+  // error handling ?!
+  // TODO(karsten1987): iterate over possible ret value
+  if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
+    RCUTILS_LOG_WARN("Error occurred while calling transition function, calling on_error.");
+    if (is_async_callback(current_state_id)) {
+      execute_async_callback(current_state_id, pre_transition_primary_state_);
+    } else {
+      auto error_cb_code = execute_callback(
+        current_state_id,
+        pre_transition_primary_state_);
+      continue_change_state(error_cb_code);
+    }
+  } else {
+    finalize_change_state(
+      cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+}
+
+void
+ChangeStateHandlerImpl::post_on_error_change_state(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn error_cb_code)
+{
+  constexpr bool publish_update = true;
+  auto error_cb_label = get_label_for_return_code(error_cb_code);
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  if (
+    rcl_lifecycle_trigger_transition_by_label(
+      &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
+  {
+    RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
+    rcutils_reset_error();
+    rcl_ret_error();
+    return;
+  }
+  finalize_change_state(
+    error_cb_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+}
+
+void
+ChangeStateHandlerImpl::finalize_change_state(bool success)
+{
+  // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
+  // 1. return is the actual transition
+  // 2. return is whether an error occurred or not
+  rcl_ret_ = success ? RCL_RET_OK : RCL_RET_ERROR;
+
+  if (header_) {
+    ChangeStateSrv::Response resp;
+    resp.success = success;
+    change_state_srv_hdl_->send_response(*header_, resp);
+    header_.reset();
+  }
+
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    // Update current state
+    current_state_ = State(state_machine_.current_state);
+  }
+  is_transitioning_.store(false);
+}
+
+bool ChangeStateHandlerImpl::is_transitioning() const
+{
+  return is_transitioning_.load();
+}
+
+bool
+ChangeStateHandlerImpl::is_async_callback(
+  unsigned int cb_id) const
+{
+  return async_cb_map_.find(static_cast<uint8_t>(cb_id)) != async_cb_map_.end();
+}
+
+node_interfaces::LifecycleNodeInterface::CallbackReturn
+ChangeStateHandlerImpl::execute_callback(
+  unsigned int cb_id, const State & previous_state) const
+{
+  // in case no callback was attached, we forward directly
+  auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+
+  auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
+  if (it != cb_map_.end()) {
+    auto callback = it->second;
+    try {
+      cb_success = callback(State(previous_state));
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
+      RCUTILS_LOG_ERROR("Original error: %s", e.what());
+      cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+  }
+  return cb_success;
+}
+
+void
+ChangeStateHandlerImpl::execute_async_callback(
+  unsigned int cb_id,
+  const State & previous_state)
+{
+  auto it = async_cb_map_.find(static_cast<uint8_t>(cb_id));
+  if (it != async_cb_map_.end()) {
+    auto callback = it->second;
+    try {
+      callback(State(previous_state), shared_from_this());
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
+      RCUTILS_LOG_ERROR("Original error: %s", e.what());
+      continue_change_state(
+        node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR);
+    }
+  } else {
+    // Note that is_async_callback should be called before execute_async_callback
+    // therefor this should never run
+    // However, to be consistent with execute_callback:
+    // in case no callback was attached, we forward directly
+    continue_change_state(
+      node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+}
+
+const char *
+ChangeStateHandlerImpl::get_label_for_return_code(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  auto cb_id = static_cast<uint8_t>(cb_return_code);
+  if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
+    return rcl_lifecycle_transition_success_label;
+  } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
+    return rcl_lifecycle_transition_failure_label;
+  }
+  return rcl_lifecycle_transition_error_label;
+}
+
+void
+ChangeStateHandlerImpl::rcl_ret_error()
+{
+  finalize_change_state(false);
+}
+
+ChangeStateHandlerImpl::~ChangeStateHandlerImpl()
+{
+  header_.reset();
+  change_state_srv_hdl_.reset();
+  node_base_interface_.reset();
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/change_state_handler_impl.hpp
+++ b/rclcpp_lifecycle/src/change_state_handler_impl.hpp
@@ -39,13 +39,11 @@ public:
   rcl_ret_t rcl_ret_;
 
   ChangeStateHandlerImpl(
+    const std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl,
     std::recursive_mutex & state_machine_mutex,
     rcl_lifecycle_state_machine_t & state_machine,
     State & current_state,
     const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface);
-
-  void set_change_state_srv_hdl(
-    const std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl);
 
   bool
   register_callback(
@@ -57,7 +55,7 @@ public:
     std::uint8_t lifecycle_transition,
     std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb);
 
-  void continue_change_state(
+  void send_callback_resp(
     node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) override;
 
   void change_state(
@@ -70,7 +68,6 @@ public:
 
 private:
   std::atomic<bool> is_transitioning_{false};
-  std::atomic<bool> utf_has_been_called_{false};
   std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl_;
   std::shared_ptr<rmw_request_id_t> header_;
 
@@ -90,9 +87,9 @@ private:
   State pre_transition_primary_state_;
   uint8_t transition_id_;
 
-  void post_utf_change_state(
+  void received_user_cb_resp(
     node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
-  void post_on_error_change_state(
+  void received_on_error_resp(
     node_interfaces::LifecycleNodeInterface::CallbackReturn error_cb_code);
   void finalize_change_state(bool success);
 
@@ -109,6 +106,9 @@ private:
   get_label_for_return_code(node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
 
   void rcl_ret_error();
+
+  bool in_non_error_transition_state() const;
+  bool in_error_transition_state() const;
 };
 }  // namespace rclcpp_lifecycle
 

--- a/rclcpp_lifecycle/src/change_state_handler_impl.hpp
+++ b/rclcpp_lifecycle/src/change_state_handler_impl.hpp
@@ -1,0 +1,115 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CHANGE_STATE_HANDLER_IMPL_HPP_
+#define CHANGE_STATE_HANDLER_IMPL_HPP_
+
+#include "rclcpp_lifecycle/change_state_handler.hpp"
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <memory>
+#include "rclcpp/service.hpp"
+#include "rmw/types.h"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+
+namespace rclcpp_lifecycle
+{
+class ChangeStateHandlerImpl : public ChangeStateHandler,
+  public std::enable_shared_from_this<ChangeStateHandlerImpl>
+{
+public:
+  using ChangeStateSrv = lifecycle_msgs::srv::ChangeState;
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code_;
+  rcl_ret_t rcl_ret_;
+
+  ChangeStateHandlerImpl(
+    std::recursive_mutex & state_machine_mutex,
+    rcl_lifecycle_state_machine_t & state_machine,
+    State & current_state,
+    const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface);
+
+  void set_change_state_srv_hdl(
+    const std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl);
+
+  bool
+  register_callback(
+    std::uint8_t lifecycle_transition,
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb);
+
+  bool
+  register_async_callback(
+    std::uint8_t lifecycle_transition,
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb);
+
+  void continue_change_state(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) override;
+
+  void change_state(
+    uint8_t transition_id,
+    const std::shared_ptr<rmw_request_id_t> header = nullptr);
+
+  bool is_transitioning() const;
+
+  virtual ~ChangeStateHandlerImpl();
+
+private:
+  std::atomic<bool> is_transitioning_{false};
+  std::atomic<bool> utf_has_been_called_{false};
+  std::shared_ptr<rclcpp::Service<ChangeStateSrv>> change_state_srv_hdl_;
+  std::shared_ptr<rmw_request_id_t> header_;
+
+  std::recursive_mutex & state_machine_mutex_;
+  rcl_lifecycle_state_machine_t & state_machine_;
+  State & current_state_;
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface_;
+
+
+  std::map<
+    std::uint8_t,
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)>> cb_map_;
+  std::map<
+    std::uint8_t,
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)>> async_cb_map_;
+
+  State pre_transition_primary_state_;
+  uint8_t transition_id_;
+
+  void post_utf_change_state(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
+  void post_on_error_change_state(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn error_cb_code);
+  void finalize_change_state(bool success);
+
+  bool
+  is_async_callback(unsigned int cb_id) const;
+
+  node_interfaces::LifecycleNodeInterface::CallbackReturn
+  execute_callback(unsigned int cb_id, const State & previous_state) const;
+
+  void
+  execute_async_callback(unsigned int cb_id, const State & previous_state);
+
+  const char *
+  get_label_for_return_code(node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
+
+  void rcl_ret_error();
+};
+}  // namespace rclcpp_lifecycle
+
+#endif  // CHANGE_STATE_HANDLER_IMPL_HPP_

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -502,12 +502,29 @@ LifecycleNode::register_on_configure(
 }
 
 bool
+LifecycleNode::register_async_on_configure(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING, fcn);
+}
+
+bool
 LifecycleNode::register_on_cleanup(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, fcn);
 }
+
+bool
+LifecycleNode::register_async_on_cleanup(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, fcn);
+}
+
 
 bool
 LifecycleNode::register_on_shutdown(
@@ -518,12 +535,30 @@ LifecycleNode::register_on_shutdown(
 }
 
 bool
+LifecycleNode::register_async_on_shutdown(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN, fcn);
+}
+
+
+bool
 LifecycleNode::register_on_activate(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, fcn);
 }
+
+bool
+LifecycleNode::register_async_on_activate(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, fcn);
+}
+
 
 bool
 LifecycleNode::register_on_deactivate(
@@ -534,12 +569,30 @@ LifecycleNode::register_on_deactivate(
 }
 
 bool
+LifecycleNode::register_async_on_deactivate(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING, fcn);
+}
+
+
+bool
 LifecycleNode::register_on_error(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, fcn);
 }
+
+bool
+LifecycleNode::register_async_on_error(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, fcn);
+}
+
 
 const State &
 LifecycleNode::get_current_state() const

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -104,11 +104,6 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
             std::string("Couldn't initialize state machine for node ") +
             node_base_interface_->get_name());
   }
-  change_state_hdl = std::make_shared<ChangeStateHandlerImpl>(
-    std::ref(state_machine_mutex_),
-    std::ref(state_machine_),
-    std::ref(current_state_),
-    node_base_interface_);
 
   current_state_ = State(state_machine_.current_state);
 
@@ -127,7 +122,6 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
         nullptr);
-      change_state_hdl->set_change_state_srv_hdl(srv_change_state_);
     }
 
     { // get_state
@@ -196,6 +190,13 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
         nullptr);
     }
   }
+
+  change_state_hdl = std::make_shared<ChangeStateHandlerImpl>(
+    srv_change_state_,
+    std::ref(state_machine_mutex_),
+    std::ref(state_machine_),
+    std::ref(current_state_),
+    node_base_interface_);
 }
 
 bool

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -104,6 +104,11 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
             std::string("Couldn't initialize state machine for node ") +
             node_base_interface_->get_name());
   }
+  change_state_hdl = std::make_shared<ChangeStateHandlerImpl>(
+    std::ref(state_machine_mutex_),
+    std::ref(state_machine_),
+    std::ref(current_state_),
+    node_base_interface_);
 
   current_state_ = State(state_machine_.current_state);
 
@@ -111,7 +116,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
     { // change_state
       auto cb = std::bind(
         &LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+        std::placeholders::_1, std::placeholders::_2);
       rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
       any_cb.set(std::move(cb));
 
@@ -122,6 +127,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interf
       node_services_interface_->add_service(
         std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
         nullptr);
+      change_state_hdl->set_change_state_srv_hdl(srv_change_state_);
     }
 
     { // get_state
@@ -197,52 +203,55 @@ LifecycleNode::LifecycleNodeInterfaceImpl::register_callback(
   std::uint8_t lifecycle_transition,
   std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
 {
-  cb_map_[lifecycle_transition] = cb;
-  return true;
+  return change_state_hdl->register_callback(lifecycle_transition, cb);
+}
+
+bool
+LifecycleNode::LifecycleNodeInterfaceImpl::register_async_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb)
+{
+  return change_state_hdl->register_async_callback(lifecycle_transition, cb);
 }
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state(
   const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<ChangeStateSrv::Request> req,
-  std::shared_ptr<ChangeStateSrv::Response> resp)
+  const std::shared_ptr<ChangeStateSrv::Request> req)
 {
-  (void)header;
   std::uint8_t transition_id;
   {
     std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+
     if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
       throw std::runtime_error("Can't get state. State machine is not initialized.");
     }
-
-    transition_id = req->transition.id;
-    // if there's a label attached to the request,
-    // we check the transition attached to this label.
-    // we further can't compare the id of the looked up transition
-    // because ros2 service call defaults all intergers to zero.
-    // that means if we call ros2 service call ... {transition: {label: shutdown}}
-    // the id of the request is 0 (zero) whereas the id from the lookup up transition
-    // can be different.
-    // the result of this is that the label takes presedence of the id.
+    // Use transition.label over transition.id if transition.label exits
+    // label has higher precedence to the id due to ROS 2 defaulting integers to 0
+    // e.g.: srv call of {transition: {label: configure}}
+    //       transition.id    = 0           -> would be equiv to "create"
+    //       transition.label = "configure" -> id is 1, use this
     if (req->transition.label.size() != 0) {
       auto rcl_transition = rcl_lifecycle_get_transition_by_label(
         state_machine_.current_state, req->transition.label.c_str());
       if (rcl_transition == nullptr) {
-        resp->success = false;
+        // send fail response printing out the requested label
+        RCUTILS_LOG_ERROR(
+          "ChangeState srv request failed: Transition label '%s'"
+          " is not available in the current state '%s'",
+          req->transition.label.c_str(), state_machine_.current_state->label);
+        ChangeStateSrv::Response resp;
+        resp.success = false;
+        srv_change_state_->send_response(*header, resp);
         return;
       }
       transition_id = static_cast<std::uint8_t>(rcl_transition->id);
+    } else {
+      transition_id = req->transition.id;
     }
   }
 
-  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code;
-  auto ret = change_state(transition_id, cb_return_code);
-  (void) ret;
-  // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
-  // 1. return is the actual transition
-  // 2. return is whether an error occurred or not
-  resp->success =
-    (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  change_state_hdl->change_state(transition_id, header);
 }
 
 void
@@ -391,116 +400,11 @@ LifecycleNode::LifecycleNodeInterfaceImpl::change_state(
   std::uint8_t transition_id,
   node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
-  constexpr bool publish_update = true;
-  State initial_state;
-  unsigned int current_state_id;
-
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR(
-        "Unable to change state for state machine for %s: %s",
-        node_base_interface_->get_name(), rcl_get_error_string().str);
-      return RCL_RET_ERROR;
-    }
-
-    // keep the initial state to pass to a transition callback
-    initial_state = State(state_machine_.current_state);
-
-    if (
-      rcl_lifecycle_trigger_transition_by_id(
-        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Unable to start transition %u from current state %s: %s",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-    current_state_id = state_machine_.current_state->id;
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  auto get_label_for_return_code =
-    [](node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) -> const char *{
-      auto cb_id = static_cast<uint8_t>(cb_return_code);
-      if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
-        return rcl_lifecycle_transition_success_label;
-      } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
-        return rcl_lifecycle_transition_failure_label;
-      }
-      return rcl_lifecycle_transition_error_label;
-    };
-
-  cb_return_code = execute_callback(current_state_id, initial_state);
-  auto transition_label = get_label_for_return_code(cb_return_code);
-
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Failed to finish transition %u. Current state is now: %s (%s)",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-    current_state_id = state_machine_.current_state->id;
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  // error handling ?!
-  // TODO(karsten1987): iterate over possible ret value
-  if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
-    RCUTILS_LOG_WARN("Error occurred while doing error handling.");
-
-    auto error_cb_code = execute_callback(current_state_id, initial_state);
-    auto error_cb_label = get_label_for_return_code(error_cb_code);
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  // This true holds in both cases where the actual callback
-  // was successful or not, since at this point we have a valid transistion
-  // to either a new primary state or error state
-  return RCL_RET_OK;
-}
-
-node_interfaces::LifecycleNodeInterface::CallbackReturn
-LifecycleNode::LifecycleNodeInterfaceImpl::execute_callback(
-  unsigned int cb_id, const State & previous_state) const
-{
-  // in case no callback was attached, we forward directly
-  auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-
-  auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
-  if (it != cb_map_.end()) {
-    auto callback = it->second;
-    try {
-      cb_success = callback(State(previous_state));
-    } catch (const std::exception & e) {
-      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
-      RCUTILS_LOG_ERROR("Original error: %s", e.what());
-      cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-    }
-  }
-  return cb_success;
+  change_state_hdl->change_state(transition_id);
+  // Set the reference cb_return_code to the last held one
+  // to hold consistency with prior implementation
+  cb_return_code = change_state_hdl->cb_return_code_;
+  return change_state_hdl->rcl_ret_;
 }
 
 const State & LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(

--- a/rclcpp_lifecycle/test/test_register_custom_async_callbacks.cpp
+++ b/rclcpp_lifecycle/test/test_register_custom_async_callbacks.cpp
@@ -1,0 +1,195 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+using lifecycle_msgs::msg::State;
+using lifecycle_msgs::msg::Transition;
+
+class TestRegisterCustomAsyncCallbacks : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+};
+
+class CustomLifecycleNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit CustomLifecycleNode(std::string node_name)
+  : rclcpp_lifecycle::LifecycleNode(std::move(node_name))
+  {}
+
+  size_t number_of_callbacks = 0;
+
+protected:
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &)
+  {
+    ADD_FAILURE();
+    ++number_of_callbacks;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &)
+  {
+    ADD_FAILURE();
+    ++number_of_callbacks;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    ADD_FAILURE();
+    ++number_of_callbacks;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State &)
+  {
+    ADD_FAILURE();
+    ++number_of_callbacks;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_shutdown(const rclcpp_lifecycle::State &)
+  {
+    ADD_FAILURE();
+    ++number_of_callbacks;
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+  }
+
+  // Custom callbacks
+
+public:
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_custom_async_configure(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<ChangeStateHandler> change_state_hdl_ptr)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
+    ++number_of_callbacks;
+    change_state_hdl_ptr->continue_change_state(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_custom_async_activate(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<ChangeStateHandler> change_state_hdl_ptr)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
+    ++number_of_callbacks;
+    change_state_hdl_ptr->continue_change_state(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_custom_async_deactivate(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<ChangeStateHandler> change_state_hdl_ptr)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
+    ++number_of_callbacks;
+    change_state_hdl_ptr->continue_change_state(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_custom_async_cleanup(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<ChangeStateHandler> change_state_hdl_ptr)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
+    ++number_of_callbacks;
+    change_state_hdl_ptr->continue_change_state(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_custom_async_shutdown(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<ChangeStateHandler> change_state_hdl_ptr)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
+    ++number_of_callbacks;
+    change_state_hdl_ptr->continue_change_state(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+};
+
+TEST_F(TestRegisterCustomAsyncCallbacks, custom_async_callbacks) {
+  auto test_node = std::make_shared<CustomLifecycleNode>("testnode");
+
+  test_node->register_async_on_configure(
+    std::bind(
+      &CustomLifecycleNode::on_custom_async_configure,
+      test_node.get(), std::placeholders::_1));
+  test_node->register_async_on_cleanup(
+    std::bind(
+      &CustomLifecycleNode::on_custom_async_cleanup,
+      test_node.get(), std::placeholders::_1));
+  test_node->register_async_on_shutdown(
+    std::bind(
+      &CustomLifecycleNode::on_custom_async_shutdown,
+      test_node.get(), std::placeholders::_1));
+  test_node->register_async_on_activate(
+    std::bind(
+      &CustomLifecycleNode::on_custom_async_activate,
+      test_node.get(), std::placeholders::_1));
+  test_node->register_async_on_deactivate(
+    std::bind(
+      &CustomLifecycleNode::on_custom_async_deactivate,
+      test_node.get(), std::placeholders::_1));
+
+  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN)).id());
+
+  // check if all callbacks were successfully overwritten
+  EXPECT_EQ(5u, test_node->number_of_callbacks);
+}


### PR DESCRIPTION
## Overview of this PR
This is a draft PR before opening a PR against rclcpp/ros2:rolling. 

The below text is going in the issue. The PR text will link to the issue. Links are removed from the below text as to not reference issues until the final issue/PR are up.

---

# [rclcpp_lifecycle] Support for async change state

## Feature request
Add the ability to defer work within a lifecycle change state request.

#### Feature description
Currently the `change_state` process for a lifecycle node completes synchronously. 
With the introduction of async services in 1709LINKHERE, the service could be made asynchronous. 
This would allow users to defer work within their respective user transition callbacks (e.g., `on_configure`, `on_activate`).

Example usage:
<details>
<summary>Expand Usage Example 1 Code: async param client</summary>

```cpp
// Usage #1: pass handler to a SharedFuture callback to get a parameter, continue the transition afterward
void
on_configure_async(const rclcpp_lifecycle::State &,
                    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> async_change_state_ptr)
{
    RCLCPP_INFO(this->get_logger(), "on_configure() {async} is called, getting `param1` from minimal_param_node");

    using ServiceResponseFuture = rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedFuture;
    auto response_received_callback =
        [logger = this->get_logger(), async_change_state_ptr](ServiceResponseFuture future)
    {
        
        auto request_response_pair = future.get();
        RCLCPP_INFO(logger, "Received parameter response: %s", request_response_pair->values[0].string_value.c_str());
        async_change_state_ptr->send_callback_resp(rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
                                                            CallbackReturn::SUCCESS);
    };

    auto request = std::make_shared<rcl_interfaces::srv::GetParameters::Request>();
    request->names.push_back("param1");
    auto result = client_->send_callback_resp(
        request, std::move(response_received_callback));
    RCLCPP_INFO(
        this->get_logger(),
        "Sending a request to the parameter server (request_id =%ld), we're going to let you know the result when ready!",
        result.request_id);
}
```
</details>

<details>
<summary>Expand Usage Example 2 Code: detached thread</summary>

```cpp
// Example usage 2: spin up and detach async thread
 void
on_activate_async(const rclcpp_lifecycle::State & state,
                    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> async_change_state_ptr)
{ 
    LifecycleNode::on_activate(state); // activates managed entities (i.e., lifecycle_publishers)
    // create a thread to do some work passing the async_change_state_ptr to the thread
    std::thread t(&LifecycleTalker::defer_on_activate_work, this, async_change_state_ptr);
    t.detach();
}
void defer_on_activate_work(std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> async_change_state_ptr)
{
    int sleep_time = 3;
    RCLCPP_INFO(this->get_logger(), "on_activate() {async} is called, sleeping is separate thread for %d seconds.", sleep_time);
    std::this_thread::sleep_for(std::chrono::seconds{sleep_time});
    RCLCPP_INFO(this->get_logger(), "on_activate() done sleeping, returning success");
    async_change_state_ptr->continue_change_state(rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
                                                            CallbackReturn::SUCCESS);
} 
```
</details>


#### Implementation considerations

Open PR for possible implementation: PRHERE

Possible implementation could include creating an object handler to handle the `change_state` process. 
This object would have the following responsibilities:

- receive change state requests from `on_change_state` (external) or `trigger_transition` (internal)
- reject any requests if the node is currently transitioning
- execute an async user callback (e.g., `on_configure`) passing itself down so the user can send a response when ready
- asynchronously receive user callback responses and continue the `change_state` process given the `CallbackReturn` (e.g., error handling)
- finalize `change_state`
    - set to a correct primary state
    - send a srv response if originally called from `on_change_state`
    - propagate errors


#### Open design questions
- outline what it means to be in a transitionary state (i.e., what assumptions can we make) and update the [Managed Node Design Doc](https://design.ros2.org/articles/node_lifecycle.html) accordingly
- return value for `change_state` is a `rcl_ret_t` that assumes the change state process will complete synchronously. 
There is also a passed-by-ref `CallbackReturn`. 
Neither of these seem to be used but proposed implementation keeps them to preserve API compatibility.

#### Related PRs:
- 1880ISSUE: publish failure leading to inconsistent state
- 2154ISSUE: lifecycle error message