### PR TITLE
Asynchronous lifecycle `change_state`

### DIFF
--- a/rclcpp_lifecycle/CMakeLists.txt
+++ b/rclcpp_lifecycle/CMakeLists.txt
@@ -22,8 +22,12 @@ find_package(rosidl_typesupport_cpp REQUIRED)
 
 ### CPP High level library
 add_library(rclcpp_lifecycle
+  src/change_state_handler_impl.cpp
   src/lifecycle_node.cpp
+  src/lifecycle_node_entities_manager.cpp
   src/lifecycle_node_interface_impl.cpp
+  src/lifecycle_node_state_manager.cpp
+  src/lifecycle_node_state_services_manager.cpp
   src/managed_entity.cpp
   src/node_interfaces/lifecycle_node_interface.cpp
   src/state.cpp
@@ -110,6 +114,14 @@ if(BUILD_TESTING)
   ament_add_gtest(test_client test/test_client.cpp TIMEOUT 120)
   if(TARGET test_client)
     target_link_libraries(test_client
+      ${PROJECT_NAME}
+      mimick
+      ${rcl_interfaces_TARGETS}
+      rclcpp::rclcpp)
+  endif()
+  ament_add_gtest(test_lifecycle_async_transitions test/test_lifecycle_async_transitions.cpp TIMEOUT 120)
+  if(TARGET test_lifecycle_async_transitions)
+    target_link_libraries(test_lifecycle_async_transitions
       ${PROJECT_NAME}
       mimick
       ${rcl_interfaces_TARGETS}

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/change_state_handler.hpp
@@ -1,0 +1,60 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_
+#define RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_
+
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+namespace rclcpp_lifecycle
+{
+/// The object passed to asynchronous change_state user transition functions
+class ChangeStateHandler
+{
+public:
+  /// Continues the change state process handling proper callback order
+  /** Used within the user defined transition callback to continue the change state process
+   *  similar to a service call response
+   *  Note this only allows sending a single response callback per object
+   *  and will not send further responses if called mutiple times on the object
+   * \param[in] cb_return_code result of user defined transition callback
+   * \return true if the response was successfully sent
+   */
+  virtual bool send_callback_resp(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) = 0;
+
+  /// Updates the state machine based on the handling of a cancelled transition
+  /**
+   * \param[in] success true if the transition cancel request was successfully handled
+   * \return true if the response was successfully sent to the state handler
+  */
+  virtual bool handle_canceled(bool success) = 0;
+
+  /// Check to see if a send_callback_resp has been cancelled
+  /**
+   * @return true if response has been cancelled
+   */
+  virtual bool is_canceling() const = 0;
+
+  // Check to see if the response has been sent
+  /**
+   * @return true if response has not been sent
+   */
+  virtual bool is_executing() const = 0;
+
+  virtual ~ChangeStateHandler() = default;
+};
+}  // namespace rclcpp_lifecycle
+
+#endif  // RCLCPP_LIFECYCLE__CHANGE_STATE_HANDLER_HPP_

--- a/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
+++ b/rclcpp_lifecycle/include/rclcpp_lifecycle/lifecycle_node.hpp
@@ -90,6 +90,7 @@
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp_lifecycle/transition.hpp"
 #include "rclcpp_lifecycle/visibility_control.h"
+#include "rclcpp_lifecycle/change_state_handler.hpp"
 
 namespace rclcpp_lifecycle
 {
@@ -1004,7 +1005,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_configure(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_configure(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the configure async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_configure(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the cleanup callback
   /**
@@ -1014,7 +1027,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_cleanup(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_cleanup(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the cleanup async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_cleanup(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the shutdown callback
   /**
@@ -1024,7 +1049,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_shutdown(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_shutdown(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the shutdown async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_shutdown(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the activate callback
   /**
@@ -1034,7 +1071,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_activate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_activate(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the activate async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_activate(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the deactivate callback
   /**
@@ -1044,7 +1093,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_deactivate(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_deactivate(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the deactivate async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_deactivate(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   /// Register the error callback
   /**
@@ -1054,7 +1115,19 @@ public:
    */
   RCLCPP_LIFECYCLE_PUBLIC
   bool
-  register_on_error(std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+  register_on_error(
+    std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn);
+
+  /// Register the error async callback
+  /**
+   * This callback will be called when the transition to this state is triggered
+   * \param[in] fcn callback function to call
+   * \return always true
+   */
+  RCLCPP_LIFECYCLE_PUBLIC
+  bool
+  register_async_on_error(
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn);
 
   RCLCPP_LIFECYCLE_PUBLIC
   CallbackReturn

--- a/rclcpp_lifecycle/src/change_state_handler_impl.cpp
+++ b/rclcpp_lifecycle/src/change_state_handler_impl.cpp
@@ -1,0 +1,81 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "change_state_handler_impl.hpp"
+
+namespace rclcpp_lifecycle
+{
+
+ChangeStateHandlerImpl::ChangeStateHandlerImpl(
+  const std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl)
+: state_manager_hdl_(state_manager_hdl)
+{
+}
+
+bool
+ChangeStateHandlerImpl::send_callback_resp(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  if (!is_canceling() && is_executing()) {
+    auto state_manager_hdl = state_manager_hdl_.lock();
+    if (state_manager_hdl) {
+      response_sent_.store(true);
+      state_manager_hdl->process_callback_resp(cb_return_code);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+ChangeStateHandlerImpl::handle_canceled(bool success)
+{
+  if (is_canceling() && is_executing()) {
+    auto state_manager_hdl = state_manager_hdl_.lock();
+    if (state_manager_hdl) {
+      response_sent_.store(true);
+      state_manager_hdl->user_handled_transition_cancel(success);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+ChangeStateHandlerImpl::is_canceling() const
+{
+  return transition_is_cancelled_.load();
+}
+
+bool
+ChangeStateHandlerImpl::is_executing() const
+{
+  return !response_sent_.load();
+}
+
+void
+ChangeStateHandlerImpl::cancel_transition()
+{
+  transition_is_cancelled_.store(true);
+}
+
+void
+ChangeStateHandlerImpl::invalidate()
+{
+  response_sent_.store(true);
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/change_state_handler_impl.hpp
+++ b/rclcpp_lifecycle/src/change_state_handler_impl.hpp
@@ -1,0 +1,59 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CHANGE_STATE_HANDLER_IMPL_HPP_
+#define CHANGE_STATE_HANDLER_IMPL_HPP_
+
+#include <memory>
+#include <atomic>
+
+#include "rclcpp_lifecycle/change_state_handler.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "lifecycle_node_state_manager.hpp"
+
+namespace rclcpp_lifecycle
+{
+
+class ChangeStateHandlerImpl : public ChangeStateHandler
+{
+public:
+  explicit ChangeStateHandlerImpl(const std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl);
+
+  bool send_callback_resp(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) override;
+
+  bool handle_canceled(bool success) override;
+
+  bool is_canceling() const override;
+
+  bool is_executing() const override;
+
+  /**
+   * @brief Marks this transition as cancelled. It is up to the user to check if the transition
+   *       has been cancelled and attempt to handle it.
+   */
+  void cancel_transition();
+
+  /**
+   * @brief Invalidate the handler by setting the response_sent_ flag to true
+   */
+  void invalidate();
+
+private:
+  std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl_;
+  std::atomic<bool> response_sent_{false};
+  std::atomic<bool> transition_is_cancelled_{false};
+};
+}  // namespace rclcpp_lifecycle
+#endif  // CHANGE_STATE_HANDLER_IMPL_HPP_

--- a/rclcpp_lifecycle/src/lifecycle_node.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node.cpp
@@ -502,10 +502,26 @@ LifecycleNode::register_on_configure(
 }
 
 bool
+LifecycleNode::register_async_on_configure(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING, fcn);
+}
+
+bool
 LifecycleNode::register_on_cleanup(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, fcn);
+}
+
+bool
+LifecycleNode::register_async_on_cleanup(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP, fcn);
 }
 
@@ -518,10 +534,26 @@ LifecycleNode::register_on_shutdown(
 }
 
 bool
+LifecycleNode::register_async_on_shutdown(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN, fcn);
+}
+
+bool
 LifecycleNode::register_on_activate(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, fcn);
+}
+
+bool
+LifecycleNode::register_async_on_activate(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING, fcn);
 }
 
@@ -534,10 +566,26 @@ LifecycleNode::register_on_deactivate(
 }
 
 bool
+LifecycleNode::register_async_on_deactivate(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING, fcn);
+}
+
+bool
 LifecycleNode::register_on_error(
   std::function<LifecycleNodeInterface::CallbackReturn(const State &)> fcn)
 {
   return impl_->register_callback(
+    lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, fcn);
+}
+
+bool
+LifecycleNode::register_async_on_error(
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> fcn)
+{
+  return impl_->register_async_callback(
     lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING, fcn);
 }
 

--- a/rclcpp_lifecycle/src/lifecycle_node_entities_manager.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_entities_manager.cpp
@@ -1,0 +1,55 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "lifecycle_node_entities_manager.hpp"
+
+namespace rclcpp_lifecycle
+{
+
+void
+LifecycleNodeEntitiesManager::on_activate() const
+{
+  for (const auto & weak_entity : weak_managed_entities_) {
+    auto entity = weak_entity.lock();
+    if (entity) {
+      entity->on_activate();
+    }
+  }
+}
+
+void
+LifecycleNodeEntitiesManager::on_deactivate() const
+{
+  for (const auto & weak_entity : weak_managed_entities_) {
+    auto entity = weak_entity.lock();
+    if (entity) {
+      entity->on_deactivate();
+    }
+  }
+}
+
+void
+LifecycleNodeEntitiesManager::add_managed_entity(
+  std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity)
+{
+  weak_managed_entities_.push_back(managed_entity);
+}
+
+void
+LifecycleNodeEntitiesManager::add_timer_handle(
+  std::shared_ptr<rclcpp::TimerBase> timer)
+{
+  weak_timers_.push_back(timer);
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_entities_manager.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_entities_manager.hpp
@@ -1,0 +1,47 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIFECYCLE_NODE_ENTITIES_MANAGER_HPP_
+#define LIFECYCLE_NODE_ENTITIES_MANAGER_HPP_
+
+#include <vector>
+#include <memory>
+#include "rclcpp_lifecycle/managed_entity.hpp"
+#include <rclcpp/timer.hpp>
+
+namespace rclcpp_lifecycle
+{
+
+class LifecycleNodeEntitiesManager
+{
+public:
+  void
+  on_activate() const;
+
+  void
+  on_deactivate() const;
+
+  void
+  add_managed_entity(std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity);
+
+  void
+  add_timer_handle(std::shared_ptr<rclcpp::TimerBase> timer);
+
+private:
+  std::vector<std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface>> weak_managed_entities_;
+  std::vector<std::weak_ptr<rclcpp::TimerBase>> weak_timers_;
+};
+
+}  // namespace rclcpp_lifecycle
+#endif  // LIFECYCLE_NODE_ENTITIES_MANAGER_HPP_

--- a/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_interface_impl.cpp
@@ -58,138 +58,24 @@ LifecycleNode::LifecycleNodeInterfaceImpl::LifecycleNodeInterfaceImpl(
 
 LifecycleNode::LifecycleNodeInterfaceImpl::~LifecycleNodeInterfaceImpl()
 {
-  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
-  rcl_ret_t ret;
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
-  }
-  if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_FATAL_NAMED(
-      "rclcpp_lifecycle",
-      "failed to destroy rcl_state_machine");
-  }
 }
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::init(bool enable_communication_interface)
 {
-  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
-  const rcl_node_options_t * node_options =
-    rcl_node_get_options(node_base_interface_->get_rcl_node_handle());
-  auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
-  state_machine_options.enable_com_interface = enable_communication_interface;
-  state_machine_options.allocator = node_options->allocator;
-
-  // The call to initialize the state machine takes
-  // currently five different typesupports for all publishers/services
-  // created within the RCL_LIFECYCLE structure.
-  // The publisher takes a C-Typesupport since the publishing (i.e. creating
-  // the message) is done fully in RCL.
-  // Services are handled in C++, so that it needs a C++ typesupport structure.
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
-  rcl_ret_t ret = rcl_lifecycle_state_machine_init(
-    &state_machine_,
-    node_handle,
-    ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
-    rosidl_typesupport_cpp::get_service_type_support_handle<ChangeStateSrv>(),
-    rosidl_typesupport_cpp::get_service_type_support_handle<GetStateSrv>(),
-    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableStatesSrv>(),
-    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
-    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
-    &state_machine_options);
-  if (ret != RCL_RET_OK) {
-    throw std::runtime_error(
-            std::string("Couldn't initialize state machine for node ") +
-            node_base_interface_->get_name());
-  }
-
-  current_state_ = State(state_machine_.current_state);
-
+  state_manager_hdl_ = std::make_shared<LifecycleNodeStateManager>();
+  state_manager_hdl_->init(
+    node_base_interface_,
+    enable_communication_interface
+  );
   if (enable_communication_interface) {
-    { // change_state
-      auto cb = std::bind(
-        &LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
-      any_cb.set(std::move(cb));
-
-      srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
-        node_base_interface_->get_shared_rcl_node_handle(),
-        &state_machine_.com_interface.srv_change_state,
-        any_cb);
-      node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
-        nullptr);
-    }
-
-    { // get_state
-      auto cb = std::bind(
-        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
-      any_cb.set(std::move(cb));
-
-      srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
-        node_base_interface_->get_shared_rcl_node_handle(),
-        &state_machine_.com_interface.srv_get_state,
-        any_cb);
-      node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
-        nullptr);
-    }
-
-    { // get_available_states
-      auto cb = std::bind(
-        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
-      any_cb.set(std::move(cb));
-
-      srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
-        node_base_interface_->get_shared_rcl_node_handle(),
-        &state_machine_.com_interface.srv_get_available_states,
-        any_cb);
-      node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
-        nullptr);
-    }
-
-    { // get_available_transitions
-      auto cb = std::bind(
-        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-      any_cb.set(std::move(cb));
-
-      srv_get_available_transitions_ =
-        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-        node_base_interface_->get_shared_rcl_node_handle(),
-        &state_machine_.com_interface.srv_get_available_transitions,
-        any_cb);
-      node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
-        nullptr);
-    }
-
-    { // get_transition_graph
-      auto cb = std::bind(
-        &LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph, this,
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
-      any_cb.set(std::move(cb));
-
-      srv_get_transition_graph_ =
-        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
-        node_base_interface_->get_shared_rcl_node_handle(),
-        &state_machine_.com_interface.srv_get_transition_graph,
-        any_cb);
-      node_services_interface_->add_service(
-        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
-        nullptr);
-    }
+    state_services_manager_hdl_ = std::make_unique<LifecycleNodeStateServicesManager>(
+      node_base_interface_,
+      node_services_interface_,
+      state_manager_hdl_
+    );
   }
+  managed_entities_manager_hdl_ = std::make_unique<LifecycleNodeEntitiesManager>();
 }
 
 bool
@@ -197,193 +83,31 @@ LifecycleNode::LifecycleNodeInterfaceImpl::register_callback(
   std::uint8_t lifecycle_transition,
   std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
 {
-  cb_map_[lifecycle_transition] = cb;
-  return true;
-}
-
-void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_change_state(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<ChangeStateSrv::Request> req,
-  std::shared_ptr<ChangeStateSrv::Response> resp)
-{
-  (void)header;
-  std::uint8_t transition_id;
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      throw std::runtime_error("Can't get state. State machine is not initialized.");
-    }
-
-    transition_id = req->transition.id;
-    // if there's a label attached to the request,
-    // we check the transition attached to this label.
-    // we further can't compare the id of the looked up transition
-    // because ros2 service call defaults all intergers to zero.
-    // that means if we call ros2 service call ... {transition: {label: shutdown}}
-    // the id of the request is 0 (zero) whereas the id from the lookup up transition
-    // can be different.
-    // the result of this is that the label takes presedence of the id.
-    if (req->transition.label.size() != 0) {
-      auto rcl_transition = rcl_lifecycle_get_transition_by_label(
-        state_machine_.current_state, req->transition.label.c_str());
-      if (rcl_transition == nullptr) {
-        resp->success = false;
-        return;
-      }
-      transition_id = static_cast<std::uint8_t>(rcl_transition->id);
-    }
-  }
-
-  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code;
-  auto ret = change_state(transition_id, cb_return_code);
-  (void) ret;
-  // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
-  // 1. return is the actual transition
-  // 2. return is whether an error occurred or not
-  resp->success =
-    (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
-}
-
-void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_get_state(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetStateSrv::Request> req,
-  std::shared_ptr<GetStateSrv::Response> resp) const
-{
-  (void)header;
-  (void)req;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-    throw std::runtime_error(
-            "Can't get state. State machine is not initialized.");
-  }
-  resp->current_state.id = static_cast<uint8_t>(state_machine_.current_state->id);
-  resp->current_state.label = state_machine_.current_state->label;
-}
-
-void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_states(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableStatesSrv::Request> req,
-  std::shared_ptr<GetAvailableStatesSrv::Response> resp) const
-{
-  (void)header;
-  (void)req;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-    throw std::runtime_error(
-            "Can't get available states. State machine is not initialized.");
-  }
-
-  resp->available_states.resize(state_machine_.transition_map.states_size);
-  for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-    resp->available_states[i].id =
-      static_cast<uint8_t>(state_machine_.transition_map.states[i].id);
-    resp->available_states[i].label =
-      static_cast<std::string>(state_machine_.transition_map.states[i].label);
-  }
-}
-
-void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_get_available_transitions(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
-{
-  (void)header;
-  (void)req;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-    throw std::runtime_error(
-            "Can't get available transitions. State machine is not initialized.");
-  }
-
-  resp->available_transitions.resize(state_machine_.current_state->valid_transition_size);
-  for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
-    lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
-
-    auto rcl_transition = state_machine_.current_state->valid_transitions[i];
-    trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
-    trans_desc.transition.label = rcl_transition.label;
-    trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
-    trans_desc.start_state.label = rcl_transition.start->label;
-    trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
-    trans_desc.goal_state.label = rcl_transition.goal->label;
-  }
-}
-
-void
-LifecycleNode::LifecycleNodeInterfaceImpl::on_get_transition_graph(
-  const std::shared_ptr<rmw_request_id_t> header,
-  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
-  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
-{
-  (void)header;
-  (void)req;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-    throw std::runtime_error(
-            "Can't get available transitions. State machine is not initialized.");
-  }
-
-  resp->available_transitions.resize(state_machine_.transition_map.transitions_size);
-  for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-    lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
-
-    auto rcl_transition = state_machine_.transition_map.transitions[i];
-    trans_desc.transition.id = static_cast<uint8_t>(rcl_transition.id);
-    trans_desc.transition.label = rcl_transition.label;
-    trans_desc.start_state.id = static_cast<uint8_t>(rcl_transition.start->id);
-    trans_desc.start_state.label = rcl_transition.start->label;
-    trans_desc.goal_state.id = static_cast<uint8_t>(rcl_transition.goal->id);
-    trans_desc.goal_state.label = rcl_transition.goal->label;
-  }
+  return state_manager_hdl_->register_callback(lifecycle_transition, cb);
 }
 
 const State &
 LifecycleNode::LifecycleNodeInterfaceImpl::get_current_state() const
 {
-  return current_state_;
+  return state_manager_hdl_->get_current_state();
 }
 
 std::vector<State>
 LifecycleNode::LifecycleNodeInterfaceImpl::get_available_states() const
 {
-  std::vector<State> states;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  states.reserve(state_machine_.transition_map.states_size);
-
-  for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
-    states.emplace_back(&state_machine_.transition_map.states[i]);
-  }
-  return states;
+  return state_manager_hdl_->get_available_states();
 }
 
 std::vector<Transition>
 LifecycleNode::LifecycleNodeInterfaceImpl::get_available_transitions() const
 {
-  std::vector<Transition> transitions;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  transitions.reserve(state_machine_.current_state->valid_transition_size);
-
-  for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
-    transitions.emplace_back(&state_machine_.current_state->valid_transitions[i]);
-  }
-  return transitions;
+  return state_manager_hdl_->get_available_transitions();
 }
 
 std::vector<Transition>
 LifecycleNode::LifecycleNodeInterfaceImpl::get_transition_graph() const
 {
-  std::vector<Transition> transitions;
-  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-  transitions.reserve(state_machine_.transition_map.transitions_size);
-
-  for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
-    transitions.emplace_back(&state_machine_.transition_map.transitions[i]);
-  }
-  return transitions;
+  return state_manager_hdl_->get_transition_graph();
 }
 
 rcl_ret_t
@@ -391,116 +115,7 @@ LifecycleNode::LifecycleNodeInterfaceImpl::change_state(
   std::uint8_t transition_id,
   node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
-  constexpr bool publish_update = true;
-  State initial_state;
-  unsigned int current_state_id;
-
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
-      RCUTILS_LOG_ERROR(
-        "Unable to change state for state machine for %s: %s",
-        node_base_interface_->get_name(), rcl_get_error_string().str);
-      return RCL_RET_ERROR;
-    }
-
-    // keep the initial state to pass to a transition callback
-    initial_state = State(state_machine_.current_state);
-
-    if (
-      rcl_lifecycle_trigger_transition_by_id(
-        &state_machine_, transition_id, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Unable to start transition %u from current state %s: %s",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-    current_state_id = state_machine_.current_state->id;
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  auto get_label_for_return_code =
-    [](node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code) -> const char *{
-      auto cb_id = static_cast<uint8_t>(cb_return_code);
-      if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
-        return rcl_lifecycle_transition_success_label;
-      } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
-        return rcl_lifecycle_transition_failure_label;
-      }
-      return rcl_lifecycle_transition_error_label;
-    };
-
-  cb_return_code = execute_callback(current_state_id, initial_state);
-  auto transition_label = get_label_for_return_code(cb_return_code);
-
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR(
-        "Failed to finish transition %u. Current state is now: %s (%s)",
-        transition_id, state_machine_.current_state->label, rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-    current_state_id = state_machine_.current_state->id;
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  // error handling ?!
-  // TODO(karsten1987): iterate over possible ret value
-  if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
-    RCUTILS_LOG_WARN("Error occurred while doing error handling.");
-
-    auto error_cb_code = execute_callback(current_state_id, initial_state);
-    auto error_cb_label = get_label_for_return_code(error_cb_code);
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
-    if (
-      rcl_lifecycle_trigger_transition_by_label(
-        &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
-    {
-      RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
-      rcutils_reset_error();
-      return RCL_RET_ERROR;
-    }
-  }
-
-  // Update the internal current_state_
-  current_state_ = State(state_machine_.current_state);
-
-  // This true holds in both cases where the actual callback
-  // was successful or not, since at this point we have a valid transistion
-  // to either a new primary state or error state
-  return RCL_RET_OK;
-}
-
-node_interfaces::LifecycleNodeInterface::CallbackReturn
-LifecycleNode::LifecycleNodeInterfaceImpl::execute_callback(
-  unsigned int cb_id, const State & previous_state) const
-{
-  // in case no callback was attached, we forward directly
-  auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-
-  auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
-  if (it != cb_map_.end()) {
-    auto callback = it->second;
-    try {
-      cb_success = callback(State(previous_state));
-    } catch (const std::exception & e) {
-      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
-      RCUTILS_LOG_ERROR("Original error: %s", e.what());
-      cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
-    }
-  }
-  return cb_success;
+  return state_manager_hdl_->change_state(transition_id, cb_return_code);
 }
 
 const State & LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
@@ -514,15 +129,11 @@ const State & LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
   const char * transition_label,
   node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
-  const rcl_lifecycle_transition_t * transition;
-  {
-    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  const rcl_lifecycle_transition_t * transition =
+    state_manager_hdl_->get_transition_by_label(transition_label);
 
-    transition =
-      rcl_lifecycle_get_transition_by_label(state_machine_.current_state, transition_label);
-  }
   if (transition) {
-    change_state(static_cast<uint8_t>(transition->id), cb_return_code);
+    state_manager_hdl_->change_state(static_cast<uint8_t>(transition->id), cb_return_code);
   }
   return get_current_state();
 }
@@ -531,7 +142,7 @@ const State &
 LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(uint8_t transition_id)
 {
   node_interfaces::LifecycleNodeInterface::CallbackReturn error;
-  change_state(transition_id, error);
+  state_manager_hdl_->change_state(transition_id, error);
   (void) error;
   return get_current_state();
 }
@@ -541,44 +152,43 @@ LifecycleNode::LifecycleNodeInterfaceImpl::trigger_transition(
   uint8_t transition_id,
   node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code)
 {
-  change_state(transition_id, cb_return_code);
+  state_manager_hdl_->change_state(transition_id, cb_return_code);
   return get_current_state();
 }
+
+bool
+LifecycleNode::LifecycleNodeInterfaceImpl::register_async_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb)
+{
+  return state_manager_hdl_->register_async_callback(lifecycle_transition, cb);
+}
+
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::add_managed_entity(
   std::weak_ptr<rclcpp_lifecycle::ManagedEntityInterface> managed_entity)
 {
-  weak_managed_entities_.push_back(managed_entity);
+  managed_entities_manager_hdl_->add_managed_entity(managed_entity);
 }
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::add_timer_handle(
   std::shared_ptr<rclcpp::TimerBase> timer)
 {
-  weak_timers_.push_back(timer);
+  managed_entities_manager_hdl_->add_timer_handle(timer);
 }
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_activate() const
 {
-  for (const auto & weak_entity : weak_managed_entities_) {
-    auto entity = weak_entity.lock();
-    if (entity) {
-      entity->on_activate();
-    }
-  }
+  managed_entities_manager_hdl_->on_activate();
 }
 
 void
 LifecycleNode::LifecycleNodeInterfaceImpl::on_deactivate() const
 {
-  for (const auto & weak_entity : weak_managed_entities_) {
-    auto entity = weak_entity.lock();
-    if (entity) {
-      entity->on_deactivate();
-    }
-  }
+  managed_entities_manager_hdl_->on_deactivate();
 }
 
 }  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_state_manager.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_state_manager.cpp
@@ -1,0 +1,614 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <memory>
+#include <chrono>
+
+#include "lifecycle_node_state_services_manager.hpp"
+#include "lifecycle_node_state_manager.hpp"
+#include "change_state_handler_impl.hpp"
+
+namespace rclcpp_lifecycle
+{
+void
+LifecycleNodeStateManager::init(
+  const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
+  bool enable_communication_interface)
+{
+  using ChangeStateSrv = lifecycle_msgs::srv::ChangeState;
+  using GetStateSrv = lifecycle_msgs::srv::GetState;
+  using GetAvailableStatesSrv = lifecycle_msgs::srv::GetAvailableStates;
+  using GetAvailableTransitionsSrv = lifecycle_msgs::srv::GetAvailableTransitions;
+
+  node_base_interface_ = node_base_interface;
+
+  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
+  const rcl_node_options_t * node_options =
+    rcl_node_get_options(node_base_interface_->get_rcl_node_handle());
+  auto state_machine_options = rcl_lifecycle_get_default_state_machine_options();
+  state_machine_options.enable_com_interface = enable_communication_interface;
+  state_machine_options.allocator = node_options->allocator;
+
+  // The call to initialize the state machine takes
+  // currently five different typesupports for all publishers/services
+  // created within the RCL_LIFECYCLE structure.
+  // The publisher takes a C-Typesupport since the publishing (i.e. creating
+  // the message) is done fully in RCL.
+  // Services are handled in C++, so that it needs a C++ typesupport structure.
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  state_machine_ = rcl_lifecycle_get_zero_initialized_state_machine();
+  rcl_ret_t ret = rcl_lifecycle_state_machine_init(
+    &state_machine_,
+    node_handle,
+    ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent),
+    rosidl_typesupport_cpp::get_service_type_support_handle<ChangeStateSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetStateSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableStatesSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
+    rosidl_typesupport_cpp::get_service_type_support_handle<GetAvailableTransitionsSrv>(),
+    &state_machine_options);
+  if (ret != RCL_RET_OK) {
+    throw std::runtime_error(
+            std::string("Couldn't initialize state machine for node ") +
+            node_base_interface_->get_name());
+  }
+
+  update_current_state_();
+}
+
+void
+LifecycleNodeStateManager::throw_runtime_error_on_uninitialized_state_machine(
+  const std::string & attempted_action) const
+{
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+    throw std::runtime_error(
+            "Can't " + attempted_action + ". State machine is not initialized.");
+  }
+}
+
+bool
+LifecycleNodeStateManager::register_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb)
+{
+  cb_map_[lifecycle_transition] = cb;
+  auto it = async_cb_map_.find(lifecycle_transition);
+  if (it != async_cb_map_.end()) {
+    async_cb_map_.erase(it);
+  }
+  return true;
+}
+
+bool
+LifecycleNodeStateManager::register_async_callback(
+  std::uint8_t lifecycle_transition,
+  std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb)
+{
+  async_cb_map_[lifecycle_transition] = cb;
+  auto it = cb_map_.find(lifecycle_transition);
+  if (it != cb_map_.end()) {
+    cb_map_.erase(it);
+  }
+  return true;
+}
+
+const State &
+LifecycleNodeStateManager::get_current_state() const
+{
+  return current_state_;
+}
+
+std::vector<State>
+LifecycleNodeStateManager::get_available_states() const
+{
+  std::vector<State> states;
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  states.reserve(state_machine_.transition_map.states_size);
+
+  for (unsigned int i = 0; i < state_machine_.transition_map.states_size; ++i) {
+    states.emplace_back(&state_machine_.transition_map.states[i]);
+  }
+  return states;
+}
+
+std::vector<Transition>
+LifecycleNodeStateManager::get_available_transitions() const
+{
+  std::vector<Transition> transitions;
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  transitions.reserve(state_machine_.current_state->valid_transition_size);
+
+  for (unsigned int i = 0; i < state_machine_.current_state->valid_transition_size; ++i) {
+    transitions.emplace_back(&state_machine_.current_state->valid_transitions[i]);
+  }
+  return transitions;
+}
+
+std::vector<Transition>
+LifecycleNodeStateManager::get_transition_graph() const
+{
+  std::vector<Transition> transitions;
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  transitions.reserve(state_machine_.transition_map.transitions_size);
+
+  for (unsigned int i = 0; i < state_machine_.transition_map.transitions_size; ++i) {
+    transitions.emplace_back(&state_machine_.transition_map.transitions[i]);
+  }
+  return transitions;
+}
+
+bool
+LifecycleNodeStateManager::is_transitioning() const
+{
+  return is_transitioning_.load();
+}
+
+rcl_ret_t
+LifecycleNodeStateManager::change_state(
+  uint8_t transition_id,
+  node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code
+)
+{
+  rcl_ret_t ret = change_state(transition_id);
+  cb_return_code = cb_return_code_;
+  return ret;
+}
+
+rcl_ret_t
+LifecycleNodeStateManager::change_state(
+  uint8_t transition_id,
+  std::function<void(bool, std::shared_ptr<rmw_request_id_t>)> callback /*= nullptr*/,
+  const std::shared_ptr<rmw_request_id_t> header /* = nullptr*/)
+{
+  if (is_transitioning()) {
+    RCUTILS_LOG_ERROR(
+      "%s currently in transition, failing requested transition id %d.",
+      node_base_interface_->get_name(),
+      transition_id);
+    if (callback) {
+      callback(false, header);
+    }
+    return RCL_RET_ERROR;
+  }
+
+  is_transitioning_.store(true);
+  send_change_state_resp_cb_ = callback;
+  change_state_header_ = header;
+  transition_id_ = transition_id;
+  rcl_ret_ = RCL_RET_OK;
+  transition_cb_completed_ = false;
+  on_error_cb_completed_ = false;
+
+  unsigned int current_state_id;
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    constexpr bool publish_update = true;
+    if (rcl_lifecycle_state_machine_is_initialized(&state_machine_) != RCL_RET_OK) {
+      RCUTILS_LOG_ERROR(
+        "Unable to change state for state machine for %s: %s",
+        node_base_interface_->get_name(), rcl_get_error_string().str);
+      rcl_ret_error();
+      return rcl_ret_;
+    }
+
+    pre_transition_primary_state_ = State(state_machine_.current_state);
+
+    if (
+      rcl_lifecycle_trigger_transition_by_id(
+        &state_machine_, transition_id_, publish_update) != RCL_RET_OK)
+    {
+      RCUTILS_LOG_ERROR(
+        "Unable to start transition %u from current state %s: %s",
+        transition_id_, state_machine_.current_state->label,
+        rcl_get_error_string().str);
+      rcutils_reset_error();
+      rcl_ret_error();
+      return rcl_ret_;
+    }
+    current_state_id = get_current_state_id();
+    update_current_state_();
+  }
+
+  if (is_async_callback(current_state_id)) {
+    execute_async_callback(current_state_id, pre_transition_primary_state_);
+  } else {
+    cb_return_code_ = execute_callback(
+      current_state_id,
+      pre_transition_primary_state_);
+    process_callback_resp(cb_return_code_);
+  }
+
+  return rcl_ret_;
+}
+
+void
+LifecycleNodeStateManager::process_callback_resp(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  // we have received a response from the user callback so we can invalidate the handler
+  invalidate_change_state_handler();
+
+  uint8_t current_state_id = get_current_state_id();
+  if (in_non_error_transition_state(current_state_id)) {
+    if (transition_cb_completed_) {
+      RCUTILS_LOG_ERROR(
+        "process_callback_resp recursively running user"
+        " transition function with id%d",
+        current_state_id);
+      rcl_ret_error();
+      return;
+    }
+    transition_cb_completed_ = true;
+    process_user_callback_resp(cb_return_code);
+  } else if (in_error_transition_state(current_state_id)) {
+    if (on_error_cb_completed_) {
+      RCUTILS_LOG_ERROR(
+        "process_callback_resp recursively running user"
+        " transition function with id%d",
+        current_state_id);
+      rcl_ret_error();
+      return;
+    }
+    on_error_cb_completed_ = true;
+    process_on_error_resp(cb_return_code);
+  } else {
+    RCUTILS_LOG_ERROR(
+      "process_callback_resp failed for %s: not in a transition state",
+      node_base_interface_->get_name());
+    rcl_ret_error();
+  }
+}
+
+bool
+LifecycleNodeStateManager::is_cancelling_transition() const
+{
+  return is_cancelling_transition_.load();
+}
+
+void
+LifecycleNodeStateManager::cancel_transition(
+  std::function<void(std::string, bool, std::shared_ptr<rmw_request_id_t>)> callback,
+  std::shared_ptr<rmw_request_id_t> header)
+{
+  if (!is_transitioning()) {
+    if (callback) {
+      callback("Not in a transition, cannot cancel", false, header);
+    }
+    return;
+  } else if (is_cancelling_transition()) {
+    if (callback) {
+      callback("Already cancelling transition", false, header);
+    }
+    return;
+  } else if (!is_running_async_callback()) {
+    if (callback) {
+      callback("Not running async transition callback, cannot cancel", false, header);
+    }
+    return;
+  }
+
+  is_cancelling_transition_.store(true);
+  send_cancel_transition_resp_cb_ = callback;
+  cancel_transition_header_ = header;
+  mark_transition_as_cancelled();
+}
+
+void
+LifecycleNodeStateManager::user_handled_transition_cancel(bool success)
+{
+  if (!is_cancelling_transition()) {
+    RCUTILS_LOG_WARN("Received user handled cancel but not in a cancel transition");
+    return;
+  }
+
+  if (success) {
+    finalize_cancel_transition("", true);
+    // If the user successfully "unwound" the transition and handled the cancel
+    // successfully, we proceed as if the transition returned a FAILURE.
+    // This allows us to use the same logic as if the user returned a FAILURE
+    // which is often recovering to the prior primary state.
+    process_callback_resp(
+      node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE);
+  } else {
+    finalize_cancel_transition("User handled cancel but did not succeed", false);
+  }
+}
+
+int
+LifecycleNodeStateManager::get_transition_id_from_request(
+  const ChangeStateSrv::Request::SharedPtr req)
+{
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+
+  // Use transition.label over transition.id if transition.label exits
+  // label has higher precedence to the id due to ROS 2 defaulting integers to 0
+  // e.g.: srv call of {transition: {label: configure}}
+  //       transition.id    = 0           -> would be equiv to "create"
+  //       transition.label = "configure" -> id is 1, use this
+  if (req->transition.label.size() != 0) {
+    auto rcl_transition = rcl_lifecycle_get_transition_by_label(
+      state_machine_.current_state, req->transition.label.c_str());
+    if (rcl_transition == nullptr) {
+      // send fail response printing out the requested label
+      RCUTILS_LOG_ERROR(
+        "ChangeState srv request failed: Transition label '%s'"
+        " is not available in the current state '%s'",
+        req->transition.label.c_str(), state_machine_.current_state->label);
+      return -1;
+    }
+    return static_cast<int>(rcl_transition->id);
+  }
+  return req->transition.id;
+}
+
+const rcl_lifecycle_transition_t *
+LifecycleNodeStateManager::get_transition_by_label(const char * label) const
+{
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  return
+    rcl_lifecycle_get_transition_by_label(state_machine_.current_state, label);
+}
+
+rcl_lifecycle_com_interface_t &
+LifecycleNodeStateManager::get_rcl_com_interface()
+{
+  return state_machine_.com_interface;
+}
+
+void
+LifecycleNodeStateManager::process_user_callback_resp(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  constexpr bool publish_update = true;
+  unsigned int current_state_id;
+
+  cb_return_code_ = cb_return_code;
+  auto transition_label = get_label_for_return_code(cb_return_code);
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    if (
+      rcl_lifecycle_trigger_transition_by_label(
+        &state_machine_, transition_label, publish_update) != RCL_RET_OK)
+    {
+      RCUTILS_LOG_ERROR(
+        "Failed to finish transition %u: Current state is now: %s (%s)",
+        transition_id_,
+        state_machine_.current_state->label,
+        rcl_get_error_string().str);
+      rcutils_reset_error();
+      rcl_ret_error();
+      return;
+    }
+    current_state_id = get_current_state_id();
+
+    update_current_state_();
+  }
+
+  // error handling ?!
+  // TODO(karsten1987): iterate over possible ret value
+  if (cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR) {
+    RCUTILS_LOG_WARN("Error occurred while calling transition function, calling on_error.");
+    if (is_async_callback(current_state_id)) {
+      execute_async_callback(current_state_id, pre_transition_primary_state_);
+    } else {
+      auto error_cb_code = execute_callback(
+        current_state_id,
+        pre_transition_primary_state_);
+      process_callback_resp(error_cb_code);
+    }
+  } else {
+    finalize_change_state(
+      cb_return_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+}
+
+void
+LifecycleNodeStateManager::process_on_error_resp(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn error_cb_code)
+{
+  constexpr bool publish_update = true;
+  auto error_cb_label = get_label_for_return_code(error_cb_code);
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  if (
+    rcl_lifecycle_trigger_transition_by_label(
+      &state_machine_, error_cb_label, publish_update) != RCL_RET_OK)
+  {
+    RCUTILS_LOG_ERROR("Failed to call cleanup on error state: %s", rcl_get_error_string().str);
+    rcutils_reset_error();
+    rcl_ret_error();
+    return;
+  }
+  finalize_change_state(
+    error_cb_code == node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+}
+
+void
+LifecycleNodeStateManager::finalize_change_state(bool success)
+{
+  // TODO(karsten1987): Lifecycle msgs have to be extended to keep both returns
+  // 1. return is the actual transition
+  // 2. return is whether an error occurred or not
+  rcl_ret_ = success ? RCL_RET_OK : RCL_RET_ERROR;
+  update_current_state_();
+
+  if (send_change_state_resp_cb_) {
+    send_change_state_resp_cb_(success, change_state_header_);
+    change_state_header_.reset();
+    send_change_state_resp_cb_ = nullptr;
+  }
+  is_transitioning_.store(false);
+}
+
+node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleNodeStateManager::execute_callback(
+  unsigned int cb_id, const State & previous_state) const
+{
+  // in case no callback was attached, we forward directly
+  auto cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+
+  auto it = cb_map_.find(static_cast<uint8_t>(cb_id));
+  if (it != cb_map_.end()) {
+    auto callback = it->second;
+    try {
+      cb_success = callback(State(previous_state));
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR("Caught exception in callback for transition %d", it->first);
+      RCUTILS_LOG_ERROR("Original error: %s", e.what());
+      cb_success = node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+  }
+  return cb_success;
+}
+
+
+bool
+LifecycleNodeStateManager::is_async_callback(
+  unsigned int cb_id) const
+{
+  return async_cb_map_.find(static_cast<uint8_t>(cb_id)) != async_cb_map_.end();
+}
+
+void
+LifecycleNodeStateManager::execute_async_callback(
+  unsigned int cb_id,
+  const State & previous_state)
+{
+  auto it = async_cb_map_.find(static_cast<uint8_t>(cb_id));
+  if (it != async_cb_map_.end()) {
+    auto callback = it->second;
+    callback(State(previous_state), create_new_change_state_handler());
+  } else {
+    // in case no callback was attached, we forward directly
+    process_callback_resp(
+      node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+}
+
+std::shared_ptr<ChangeStateHandler>
+LifecycleNodeStateManager::create_new_change_state_handler()
+{
+  change_state_hdl_ = std::make_shared<ChangeStateHandlerImpl>(weak_from_this());
+  return change_state_hdl_;
+}
+
+const char *
+LifecycleNodeStateManager::get_label_for_return_code(
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code)
+{
+  auto cb_id = static_cast<uint8_t>(cb_return_code);
+  if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS) {
+    return rcl_lifecycle_transition_success_label;
+  } else if (cb_id == lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_FAILURE) {
+    return rcl_lifecycle_transition_failure_label;
+  }
+  return rcl_lifecycle_transition_error_label;
+}
+
+void
+LifecycleNodeStateManager::rcl_ret_error()
+{
+  finalize_change_state(false);
+}
+
+void
+LifecycleNodeStateManager::update_current_state_()
+{
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  current_state_ = State(state_machine_.current_state);
+}
+
+uint8_t
+LifecycleNodeStateManager::get_current_state_id() const
+{
+  std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+  return state_machine_.current_state->id;
+}
+
+bool
+LifecycleNodeStateManager::in_non_error_transition_state(
+  uint8_t current_state_id) const
+{
+  return current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING ||
+         current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP ||
+         current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN ||
+         current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING ||
+         current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING;
+}
+
+bool
+LifecycleNodeStateManager::in_error_transition_state(
+  uint8_t current_state_id) const
+{
+  return current_state_id == lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING;
+}
+
+bool
+LifecycleNodeStateManager::is_running_async_callback() const
+{
+  return change_state_hdl_ && change_state_hdl_->is_executing();
+}
+
+void
+LifecycleNodeStateManager::invalidate_change_state_handler()
+{
+  if (change_state_hdl_) {
+    change_state_hdl_->invalidate();
+    change_state_hdl_.reset();
+  }
+}
+
+bool
+LifecycleNodeStateManager::mark_transition_as_cancelled()
+{
+  if (change_state_hdl_) {
+    change_state_hdl_->cancel_transition();
+    return true;
+  }
+  return false;
+}
+
+void
+LifecycleNodeStateManager::finalize_cancel_transition(const std::string & error_msg, bool success)
+{
+  if (send_cancel_transition_resp_cb_) {
+    send_cancel_transition_resp_cb_(error_msg, success, cancel_transition_header_);
+    cancel_transition_header_.reset();
+    send_cancel_transition_resp_cb_ = nullptr;
+  }
+  is_cancelling_transition_.store(false);
+}
+
+LifecycleNodeStateManager::~LifecycleNodeStateManager()
+{
+  rcl_node_t * node_handle = node_base_interface_->get_rcl_node_handle();
+  rcl_ret_t ret;
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_machine_mutex_);
+    ret = rcl_lifecycle_state_machine_fini(&state_machine_, node_handle);
+  }
+  if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_FATAL_NAMED(
+      "rclcpp_lifecycle",
+      "failed to destroy rcl_state_machine");
+  }
+  send_change_state_resp_cb_ = nullptr;
+  send_cancel_transition_resp_cb_ = nullptr;
+  change_state_header_.reset();
+  cancel_transition_header_.reset();
+  node_base_interface_.reset();
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_state_manager.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_state_manager.hpp
@@ -1,0 +1,192 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIFECYCLE_NODE_STATE_MANAGER_HPP_
+#define LIFECYCLE_NODE_STATE_MANAGER_HPP_
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "lifecycle_msgs/msg/transition_event.hpp"
+#include "lifecycle_msgs/srv/cancel_transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/srv/get_available_states.hpp"
+#include "lifecycle_msgs/srv/get_available_transitions.hpp"
+
+#include "rcl_lifecycle/rcl_lifecycle.h"
+
+#include "rclcpp/macros.hpp"
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+#include "rmw/types.h"
+
+namespace rclcpp_lifecycle
+{
+class ChangeStateHandlerImpl;  // forward declaration
+
+class LifecycleNodeStateManager
+  : public std::enable_shared_from_this<LifecycleNodeStateManager>
+{
+public:
+  using ChangeStateSrv = lifecycle_msgs::srv::ChangeState;
+  using CancelTransitionSrv = lifecycle_msgs::srv::CancelTransition;
+
+  void init(
+    const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
+    bool enable_communication_interface);
+
+  void throw_runtime_error_on_uninitialized_state_machine(const std::string & attempted_action)
+  const;
+
+  bool
+  register_callback(
+    std::uint8_t lifecycle_transition,
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)> & cb);
+
+  bool
+  register_async_callback(
+    std::uint8_t lifecycle_transition,
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)> & cb);
+
+  const State & get_current_state() const;
+
+  std::vector<State> get_available_states() const;
+
+  std::vector<Transition> get_available_transitions() const;
+
+  std::vector<Transition> get_transition_graph() const;
+
+  bool is_transitioning() const;
+
+  rcl_ret_t change_state(
+    uint8_t transition_id,
+    node_interfaces::LifecycleNodeInterface::CallbackReturn & cb_return_code);
+
+  rcl_ret_t change_state(
+    uint8_t transition_id,
+    std::function<void(bool, std::shared_ptr<rmw_request_id_t>)> callback = nullptr,
+    const std::shared_ptr<rmw_request_id_t> header = nullptr);
+
+  void process_callback_resp(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
+
+  bool is_cancelling_transition() const;
+
+  void cancel_transition(
+    std::function<void(std::string, bool, std::shared_ptr<rmw_request_id_t>)> callback = nullptr,
+    const std::shared_ptr<rmw_request_id_t> header = nullptr);
+
+  void user_handled_transition_cancel(bool success);
+
+  /**
+   * @brief Gets the transition id prioritizing request->transition.label over
+   *        request->transition.id if the label is set
+   *        Throws exception if state_machine_ is not initialized
+   * @return the transition id, returns -1 if the transition does not exist
+  */
+  int get_transition_id_from_request(const ChangeStateSrv::Request::SharedPtr req);
+
+  const rcl_lifecycle_transition_t * get_transition_by_label(const char * label) const;
+
+  rcl_lifecycle_com_interface_t & get_rcl_com_interface();
+
+  virtual ~LifecycleNodeStateManager();
+
+private:
+  /*NodeInterfaces*/
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface_;
+
+  /*StateMachine & Callback Maps*/
+  mutable std::recursive_mutex state_machine_mutex_;
+  rcl_lifecycle_state_machine_t state_machine_;
+  State current_state_;
+  std::map<
+    std::uint8_t,
+    std::function<node_interfaces::LifecycleNodeInterface::CallbackReturn(const State &)>> cb_map_;
+  std::map<
+    std::uint8_t,
+    std::function<void(const State &, std::shared_ptr<ChangeStateHandler>)>> async_cb_map_;
+
+  /*ChangeState Members*/
+  std::shared_ptr<ChangeStateHandlerImpl> change_state_hdl_;
+  std::function<void(bool, std::shared_ptr<rmw_request_id_t>)> send_change_state_resp_cb_;
+  std::shared_ptr<rmw_request_id_t> change_state_header_;
+  std::atomic<bool> is_transitioning_{false};
+  State pre_transition_primary_state_;
+  uint8_t transition_id_;
+  bool transition_cb_completed_;
+  bool on_error_cb_completed_;
+
+  node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code_;
+  rcl_ret_t rcl_ret_;
+
+  /*ChangeState Helpers*/
+  void process_user_callback_resp(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
+
+  void process_on_error_resp(
+    node_interfaces::LifecycleNodeInterface::CallbackReturn error_cb_code);
+
+  void finalize_change_state(bool success);
+
+  node_interfaces::LifecycleNodeInterface::CallbackReturn
+  execute_callback(unsigned int cb_id, const State & previous_state) const;
+
+  bool is_async_callback(unsigned int cb_id) const;
+
+  void execute_async_callback(unsigned int cb_id, const State & previous_state);
+
+  std::shared_ptr<ChangeStateHandler> create_new_change_state_handler();
+
+  const char *
+  get_label_for_return_code(node_interfaces::LifecycleNodeInterface::CallbackReturn cb_return_code);
+
+  void rcl_ret_error();
+
+  void update_current_state_();
+
+  uint8_t get_current_state_id() const;
+
+  bool in_non_error_transition_state(uint8_t) const;
+
+  bool in_error_transition_state(uint8_t) const;
+
+  /*CancelTransition Members*/
+  std::function<void(std::string, bool,
+    std::shared_ptr<rmw_request_id_t>)> send_cancel_transition_resp_cb_;
+  std::shared_ptr<rmw_request_id_t> cancel_transition_header_;
+  std::atomic<bool> is_cancelling_transition_{false};
+
+  /*CancelTransition Helpers*/
+  bool is_running_async_callback() const;
+
+  void invalidate_change_state_handler();
+
+  bool mark_transition_as_cancelled();
+
+  void finalize_cancel_transition(const std::string & error_msg, bool success);
+};
+}  // namespace rclcpp_lifecycle
+#endif  // LIFECYCLE_NODE_STATE_MANAGER_HPP_

--- a/rclcpp_lifecycle/src/lifecycle_node_state_services_manager.cpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_state_services_manager.cpp
@@ -1,0 +1,297 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include <string>
+#include <utility>
+
+#include "lifecycle_node_state_services_manager.hpp"
+#include "lifecycle_node_state_manager.hpp"
+
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+namespace rclcpp_lifecycle
+{
+
+LifecycleNodeStateServicesManager::LifecycleNodeStateServicesManager(
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
+  std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_interface,
+  const std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl
+)
+: state_manager_hdl_(state_manager_hdl)
+{
+  if (auto state_manager_hdl = state_manager_hdl_.lock()) {
+    rcl_lifecycle_com_interface_t & state_machine_com_interface =
+      state_manager_hdl->get_rcl_com_interface();
+    { // change_state
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_change_state, this,
+        std::placeholders::_1, std::placeholders::_2);
+      rclcpp::AnyServiceCallback<ChangeStateSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_change_state_ = std::make_shared<rclcpp::Service<ChangeStateSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        &state_machine_com_interface.srv_change_state,
+        any_cb);
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_change_state_),
+        nullptr);
+    }
+
+    { // get_state
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_get_state, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetStateSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_state_ = std::make_shared<rclcpp::Service<GetStateSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        &state_machine_com_interface.srv_get_state,
+        any_cb);
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_state_),
+        nullptr);
+    }
+
+    { // get_available_states
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_get_available_states, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableStatesSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_available_states_ = std::make_shared<rclcpp::Service<GetAvailableStatesSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        &state_machine_com_interface.srv_get_available_states,
+        any_cb);
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_states_),
+        nullptr);
+    }
+
+    { // get_available_transitions
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_get_available_transitions, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_available_transitions_ =
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        &state_machine_com_interface.srv_get_available_transitions,
+        any_cb);
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_available_transitions_),
+        nullptr);
+    }
+
+    { // get_transition_graph
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_get_transition_graph, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+      rclcpp::AnyServiceCallback<GetAvailableTransitionsSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      srv_get_transition_graph_ =
+        std::make_shared<rclcpp::Service<GetAvailableTransitionsSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        &state_machine_com_interface.srv_get_transition_graph,
+        any_cb);
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_get_transition_graph_),
+        nullptr);
+    }
+
+    { // cancel_transition
+      auto cb = std::bind(
+        &LifecycleNodeStateServicesManager::on_cancel_transition, this,
+        std::placeholders::_1, std::placeholders::_2);
+      rclcpp::AnyServiceCallback<CancelTransitionSrv> any_cb;
+      any_cb.set(std::move(cb));
+
+      rcl_service_options_t cancel_srv_options = rcl_service_get_default_options();
+
+      srv_cancel_transition_ =
+        std::make_shared<rclcpp::Service<CancelTransitionSrv>>(
+        node_base_interface->get_shared_rcl_node_handle(),
+        std::string(node_base_interface->get_fully_qualified_name()) + "/cancel_transition",
+        any_cb,
+        cancel_srv_options);
+
+      node_services_interface->add_service(
+        std::dynamic_pointer_cast<rclcpp::ServiceBase>(srv_cancel_transition_),
+        nullptr);
+    }
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::send_change_state_resp(
+  bool success,
+  const std::shared_ptr<rmw_request_id_t> header) const
+{
+  auto resp = std::make_unique<ChangeStateSrv::Response>();
+  resp->success = success;
+  srv_change_state_->send_response(*header, *resp);
+}
+
+void
+LifecycleNodeStateServicesManager::send_cancel_transition_resp(
+  const std::string & error_msg,
+  bool success,
+  const std::shared_ptr<rmw_request_id_t> header) const
+{
+  auto resp = std::make_unique<CancelTransitionSrv::Response>();
+  resp->success = success;
+  resp->error_msg = error_msg;
+  srv_cancel_transition_->send_response(*header, *resp);
+}
+
+void
+LifecycleNodeStateServicesManager::on_change_state(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<ChangeStateSrv::Request> req)
+{
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("change state");
+    int transition_id = state_hdl->get_transition_id_from_request(req);
+    if (transition_id < 0) {
+      send_change_state_resp(false, header);
+    } else {
+      state_hdl->change_state(
+        transition_id,
+        std::bind(
+          &LifecycleNodeStateServicesManager::send_change_state_resp,
+          this, std::placeholders::_1, std::placeholders::_2),
+        header);
+    }
+  } else { /*Unable to lock StateManager*/
+    send_change_state_resp(false, header);
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::on_get_state(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetStateSrv::Request> req,
+  std::shared_ptr<GetStateSrv::Response> resp) const
+{
+  (void)header;
+  (void)req;
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("get state");
+    const State & current_state = state_hdl->get_current_state();
+    resp->current_state.id = current_state.id();
+    resp->current_state.label = current_state.label();
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::on_get_available_states(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableStatesSrv::Request> req,
+  std::shared_ptr<GetAvailableStatesSrv::Response> resp) const
+{
+  (void)header;
+  (void)req;
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("get available states");
+    std::vector<State> available_states = state_hdl->get_available_states();
+    resp->available_states.resize(available_states.size());
+    for (unsigned int i = 0; i < available_states.size(); ++i) {
+      resp->available_states[i].id = available_states[i].id();
+      resp->available_states[i].label = available_states[i].label();
+    }
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::on_get_available_transitions(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
+{
+  (void)header;
+  (void)req;
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("get available transitions");
+    std::vector<Transition> available_transitions = state_hdl->get_available_transitions();
+    copy_transitions_vector_to_resp(available_transitions, resp);
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::on_get_transition_graph(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
+{
+  (void)header;
+  (void)req;
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("get transition graph");
+    std::vector<Transition> available_transitions = state_hdl->get_transition_graph();
+    copy_transitions_vector_to_resp(available_transitions, resp);
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::on_cancel_transition(
+  const std::shared_ptr<rmw_request_id_t> header,
+  const std::shared_ptr<CancelTransitionSrv::Request> req) const
+{
+  (void) req;
+  auto state_hdl = state_manager_hdl_.lock();
+  if (state_hdl) {
+    state_hdl->throw_runtime_error_on_uninitialized_state_machine("cancel transition");
+    state_hdl->cancel_transition(
+      std::bind(
+        &LifecycleNodeStateServicesManager::send_cancel_transition_resp, this,
+        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
+      header);
+  } else {
+    send_cancel_transition_resp("LifecycleNodeStateManager is not available.", false, header);
+  }
+}
+
+void
+LifecycleNodeStateServicesManager::copy_transitions_vector_to_resp(
+  const std::vector<Transition> transition_vec,
+  std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const
+{
+  resp->available_transitions.resize(transition_vec.size());
+  for (unsigned int i = 0; i < transition_vec.size(); ++i) {
+    lifecycle_msgs::msg::TransitionDescription & trans_desc = resp->available_transitions[i];
+
+    Transition transition = transition_vec[i];
+    trans_desc.transition.id = transition.id();
+    trans_desc.transition.label = transition.label();
+    trans_desc.start_state.id = transition.start_state().id();
+    trans_desc.start_state.label = transition.start_state().label();
+    trans_desc.goal_state.id = transition.goal_state().id();
+    trans_desc.goal_state.label = transition.goal_state().label();
+  }
+}
+
+}  // namespace rclcpp_lifecycle

--- a/rclcpp_lifecycle/src/lifecycle_node_state_services_manager.hpp
+++ b/rclcpp_lifecycle/src/lifecycle_node_state_services_manager.hpp
@@ -1,0 +1,126 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIFECYCLE_NODE_STATE_SERVICES_MANAGER_HPP_
+#define LIFECYCLE_NODE_STATE_SERVICES_MANAGER_HPP_
+
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "rcl_lifecycle/rcl_lifecycle.h"
+
+#include "lifecycle_msgs/msg/transition_event.hpp"
+#include "lifecycle_msgs/srv/cancel_transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+#include "lifecycle_msgs/srv/get_available_states.hpp"
+#include "lifecycle_msgs/srv/get_available_transitions.hpp"
+
+#include "rclcpp/node_interfaces/node_base_interface.hpp"
+#include "rclcpp/node_interfaces/node_services_interface.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+
+#include "rclcpp_lifecycle/transition.hpp"
+#include "lifecycle_node_state_manager.hpp"
+
+namespace rclcpp_lifecycle
+{
+class LifecycleNodeStateServicesManager
+{
+  using CancelTransitionSrv = lifecycle_msgs::srv::CancelTransition;
+  using ChangeStateSrv = lifecycle_msgs::srv::ChangeState;
+  using GetStateSrv = lifecycle_msgs::srv::GetState;
+  using GetAvailableStatesSrv = lifecycle_msgs::srv::GetAvailableStates;
+  using GetAvailableTransitionsSrv = lifecycle_msgs::srv::GetAvailableTransitions;
+  using TransitionEventMsg = lifecycle_msgs::msg::TransitionEvent;
+
+public:
+  LifecycleNodeStateServicesManager(
+    std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface,
+    std::shared_ptr<rclcpp::node_interfaces::NodeServicesInterface> node_services_interface,
+    const std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl);
+
+  void send_change_state_resp(
+    bool success,
+    const std::shared_ptr<rmw_request_id_t> header) const;
+
+  void send_cancel_transition_resp(
+    const std::string & error_msg,
+    bool success,
+    const std::shared_ptr<rmw_request_id_t> header) const;
+
+private:
+  void
+  on_change_state(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<ChangeStateSrv::Request> req);
+
+  void
+  on_get_state(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<GetStateSrv::Request> req,
+    std::shared_ptr<GetStateSrv::Response> resp) const;
+
+  void
+  on_get_available_states(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<GetAvailableStatesSrv::Request> req,
+    std::shared_ptr<GetAvailableStatesSrv::Response> resp) const;
+
+  void
+  on_get_available_transitions(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
+
+  void
+  on_get_transition_graph(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<GetAvailableTransitionsSrv::Request> req,
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
+
+  void
+  on_cancel_transition(
+    const std::shared_ptr<rmw_request_id_t> header,
+    const std::shared_ptr<CancelTransitionSrv::Request> req) const;
+
+  void
+  copy_transitions_vector_to_resp(
+    const std::vector<Transition> transition_vec,
+    std::shared_ptr<GetAvailableTransitionsSrv::Response> resp) const;
+
+  using ChangeStateSrvPtr = std::shared_ptr<rclcpp::Service<ChangeStateSrv>>;
+  using GetStateSrvPtr = std::shared_ptr<rclcpp::Service<GetStateSrv>>;
+  using GetAvailableStatesSrvPtr =
+    std::shared_ptr<rclcpp::Service<GetAvailableStatesSrv>>;
+  using GetAvailableTransitionsSrvPtr =
+    std::shared_ptr<rclcpp::Service<GetAvailableTransitionsSrv>>;
+  using GetTransitionGraphSrvPtr =
+    std::shared_ptr<rclcpp::Service<GetAvailableTransitionsSrv>>;
+  using CancelTransitionSrvPtr =
+    std::shared_ptr<rclcpp::Service<CancelTransitionSrv>>;
+
+  ChangeStateSrvPtr srv_change_state_;
+  GetStateSrvPtr srv_get_state_;
+  GetAvailableStatesSrvPtr srv_get_available_states_;
+  GetAvailableTransitionsSrvPtr srv_get_available_transitions_;
+  GetTransitionGraphSrvPtr srv_get_transition_graph_;
+  CancelTransitionSrvPtr srv_cancel_transition_;
+
+  std::weak_ptr<LifecycleNodeStateManager> state_manager_hdl_;
+};
+
+}  // namespace rclcpp_lifecycle
+#endif  // LIFECYCLE_NODE_STATE_SERVICES_MANAGER_HPP_

--- a/rclcpp_lifecycle/test/test_lifecycle_async_transitions.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_async_transitions.cpp
@@ -1,0 +1,588 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Service client test was adopted from:
+ * https://github.com/ros2/demos/blob/master/lifecycle/src/lifecycle_service_client.cpp
+ */
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+#include "lifecycle_msgs/msg/transition_description.hpp"
+#include "lifecycle_msgs/srv/cancel_transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+
+#include "rcl_lifecycle/rcl_lifecycle.h"
+
+#include "rclcpp/node_interfaces/node_graph.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "rcpputils/scope_exit.hpp"
+
+#include "./mocking_utils/patch.hpp"
+
+using namespace std::chrono_literals;
+using lifecycle_msgs::msg::State;
+
+constexpr char const * ping_pong_node_name = "ping_pong_node";
+
+constexpr char const * node_get_state_topic = "/ping_pong_node/get_state";
+constexpr char const * node_change_state_topic = "/ping_pong_node/change_state";
+constexpr char const * node_cancel_transition_topic =
+  "/ping_pong_node/cancel_transition";
+
+const lifecycle_msgs::msg::State unknown_state = lifecycle_msgs::msg::State();
+
+class PingPongAsyncLCNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  /**
+   * @brief `PingPong` refers to transition callback FAILURE->SUCCESS->... returns
+   *        It has 2 notable exceptions:
+   *        - on_shutdown_async ping pongs ERROR -> SUCCESS (FAILURE is undefined for this transition)
+   *        - on_error_async always returns SUCCESS
+   *        It also contains a function to switch to a detached thread wrapper of each callback
+  */
+  explicit PingPongAsyncLCNode(std::string node_name)
+  : rclcpp_lifecycle::LifecycleNode(std::move(node_name))
+  {
+    register_async_on_configure(
+      std::bind(
+        &PingPongAsyncLCNode::on_configure_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_activate(
+      std::bind(
+        &PingPongAsyncLCNode::on_activate_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_deactivate(
+      std::bind(
+        &PingPongAsyncLCNode::on_deactivate_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_cleanup(
+      std::bind(
+        &PingPongAsyncLCNode::on_cleanup_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_shutdown(
+      std::bind(
+        &PingPongAsyncLCNode::on_shutdown_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_error(
+      std::bind(
+        &PingPongAsyncLCNode::on_error_async,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+  }
+
+  void switch_to_detached_thread_callbacks()
+  {
+    register_async_on_configure(
+      std::bind(
+        &PingPongAsyncLCNode::on_configure_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_activate(
+      std::bind(
+        &PingPongAsyncLCNode::on_activate_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_deactivate(
+      std::bind(
+        &PingPongAsyncLCNode::on_deactivate_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_cleanup(
+      std::bind(
+        &PingPongAsyncLCNode::on_cleanup_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_shutdown(
+      std::bind(
+        &PingPongAsyncLCNode::on_shutdown_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+    register_async_on_error(
+      std::bind(
+        &PingPongAsyncLCNode::on_error_async_dt,
+        this, std::placeholders::_1,
+        std::placeholders::_2));
+  }
+
+  size_t number_of_callbacks = 0;
+
+protected:
+  // Simulates fail -> success -> fail -> success -> ...
+  bool ret_success{false};
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  ping_pong_ret_fail_success()
+  {
+    auto ret = ret_success ?
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
+    ret_success = !ret_success;
+    return ret;
+  }
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  ping_pong_ret_error_success()
+  {
+    auto ret = ret_success ?
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    ret_success = !ret_success;
+    return ret;
+  }
+
+  // Async callbacks
+  void
+  on_configure_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(ping_pong_ret_fail_success());
+  }
+
+  void
+  on_activate_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(ping_pong_ret_fail_success());
+  }
+
+  void
+  on_deactivate_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(ping_pong_ret_fail_success());
+  }
+
+  void
+  on_cleanup_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(ping_pong_ret_fail_success());
+  }
+
+  void on_shutdown_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(ping_pong_ret_error_success());
+  }
+
+  void on_error_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_ERRORPROCESSING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  // Detached thread callbacks
+  void
+  on_configure_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_configure_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+
+  void
+  on_activate_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_activate_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+
+  void
+  on_deactivate_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_deactivate_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+
+  void
+  on_cleanup_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_cleanup_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+
+  void on_shutdown_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_shutdown_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+
+  void on_error_async_dt(
+    const rclcpp_lifecycle::State & s,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    std::thread t(&PingPongAsyncLCNode::on_error_async, this,
+      s, change_state_hdl);
+    t.detach();
+  }
+};
+
+
+class LifecycleServiceClient : public rclcpp::Node
+{
+public:
+  explicit LifecycleServiceClient(std::string node_name)
+  : Node(node_name)
+  {
+    client_get_state_ = this->create_client<lifecycle_msgs::srv::GetState>(
+      node_get_state_topic);
+    client_change_state_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
+      node_change_state_topic);
+    client_cancel_transition_ = this->create_client<lifecycle_msgs::srv::CancelTransition>(
+      node_cancel_transition_topic);
+  }
+
+  lifecycle_msgs::msg::State
+  get_state(std::chrono::seconds time_out = 1s)
+  {
+    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+
+    if (!client_get_state_->wait_for_service(time_out)) {
+      return unknown_state;
+    }
+
+    auto future_result = client_get_state_->async_send_request(request);
+    auto future_status = future_result.wait_for(time_out);
+
+    if (future_status != std::future_status::ready) {
+      return unknown_state;
+    }
+
+    auto result = future_result.get();
+    if (result) {
+      return result->current_state;
+    } else {
+      return unknown_state;
+    }
+  }
+
+  bool
+  change_state(std::uint8_t transition, std::chrono::seconds time_out = 1s)
+  {
+    auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+    request->transition.id = transition;
+
+    if (!client_change_state_->wait_for_service(time_out)) {
+      return false;
+    }
+
+    auto future_result = client_change_state_->async_send_request(request);
+    auto future_status = future_result.wait_for(time_out);
+
+    if (future_status != std::future_status::ready) {
+      return false;
+    }
+
+    return future_result.get()->success;
+  }
+
+  bool cancel_transition(std::chrono::seconds time_out = 1s)
+  {
+    auto request = std::make_shared<lifecycle_msgs::srv::CancelTransition::Request>();
+
+    if (!client_cancel_transition_->wait_for_service(time_out)) {
+      return false;
+    }
+
+    auto future_result = client_cancel_transition_->async_send_request(request);
+    auto future_status = future_result.wait_for(time_out);
+
+    if (future_status != std::future_status::ready) {
+      return false;
+    }
+
+    return future_result.get()->success;
+  }
+
+private:
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::CancelTransition>>
+  client_cancel_transition_;
+};
+
+
+class TestLifecycleAsyncTransitions : public ::testing::Test
+{
+protected:
+  PingPongAsyncLCNode * lifecycle_node() {return lifecycle_node_.get();}
+  LifecycleServiceClient * lifecycle_client() {return lifecycle_client_.get();}
+
+private:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    lifecycle_node_ = std::make_shared<PingPongAsyncLCNode>(ping_pong_node_name);
+    lifecycle_client_ = std::make_shared<LifecycleServiceClient>("client");
+    spinner_ = std::thread(&TestLifecycleAsyncTransitions::spin, this);
+  }
+
+  void TearDown() override
+  {
+    {
+      std::lock_guard<std::mutex> guard(shutdown_mutex_);
+      rclcpp::shutdown();
+    }
+    spinner_.join();
+  }
+
+  void spin()
+  {
+    while (true) {
+      {
+        std::lock_guard<std::mutex> guard(shutdown_mutex_);
+        if (!rclcpp::ok()) {
+          break;
+        }
+        rclcpp::spin_some(lifecycle_node_->get_node_base_interface());
+        rclcpp::spin_some(lifecycle_client_);
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  std::shared_ptr<PingPongAsyncLCNode> lifecycle_node_;
+  std::shared_ptr<LifecycleServiceClient> lifecycle_client_;
+  std::mutex shutdown_mutex_;
+  std::thread spinner_;
+};
+
+
+TEST_F(TestLifecycleAsyncTransitions, lifecycle_async_transitions_w_immediate_ret) {
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Configure 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Activate 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Deactivate 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Cleanup 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Shutdown(Error) -> ErrorProcessing(Success)
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Shutdown(Success)
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+
+  // 2 * change_state calls + 1 ErrorProcessing
+  EXPECT_EQ(lifecycle_node()->number_of_callbacks, 11);
+}
+
+TEST_F(TestLifecycleAsyncTransitions, lifecycle_async_transitions_w_detached_thread) {
+  lifecycle_node()->switch_to_detached_thread_callbacks();
+
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Configure 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Activate 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Deactivate 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Cleanup 2x
+  EXPECT_FALSE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Shutdown(Error) -> ErrorProcessing(Success)
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Shutdown(Success)
+  EXPECT_TRUE(
+    lifecycle_client()->change_state(
+      lifecycle_msgs::msg::Transition::TRANSITION_UNCONFIGURED_SHUTDOWN));
+  EXPECT_EQ(
+    lifecycle_client()->get_state().id,
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+
+  // 2 * change_state calls + 1 ErrorProcessing
+  EXPECT_EQ(lifecycle_node()->number_of_callbacks, 11);
+}

--- a/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
+++ b/rclcpp_lifecycle/test/test_lifecycle_service_client.cpp
@@ -28,6 +28,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
 #include "lifecycle_msgs/msg/transition_description.hpp"
+#include "lifecycle_msgs/srv/cancel_transition.hpp"
 #include "lifecycle_msgs/srv/change_state.hpp"
 #include "lifecycle_msgs/srv/get_available_states.hpp"
 #include "lifecycle_msgs/srv/get_available_transitions.hpp"
@@ -54,6 +55,8 @@ constexpr char const * node_get_available_transitions_topic =
   "/lc_talker/get_available_transitions";
 constexpr char const * node_get_transition_graph_topic =
   "/lc_talker/get_transition_graph";
+constexpr char const * node_cancel_transition_topic =
+  "/lc_talker/cancel_transition";
 const lifecycle_msgs::msg::State unknown_state = lifecycle_msgs::msg::State();
 
 class EmptyLifecycleNode : public rclcpp_lifecycle::LifecycleNode
@@ -82,6 +85,8 @@ public:
       node_get_state_topic);
     client_change_state_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
       node_change_state_topic);
+    client_cancel_transition_ = this->create_client<lifecycle_msgs::srv::CancelTransition>(
+      node_cancel_transition_topic);
   }
 
   lifecycle_msgs::msg::State
@@ -199,6 +204,24 @@ public:
     return std::vector<lifecycle_msgs::msg::TransitionDescription>();
   }
 
+  bool cancel_transition(std::chrono::seconds time_out = 1s)
+  {
+    auto request = std::make_shared<lifecycle_msgs::srv::CancelTransition::Request>();
+
+    if (!client_cancel_transition_->wait_for_service(time_out)) {
+      return false;
+    }
+
+    auto future_result = client_cancel_transition_->async_send_request(request);
+    auto future_status = future_result.wait_for(time_out);
+
+    if (future_status != std::future_status::ready) {
+      return false;
+    }
+
+    return future_result.get()->success;
+  }
+
 private:
   std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetAvailableStates>>
   client_get_available_states_;
@@ -208,6 +231,8 @@ private:
   client_get_transition_graph_;
   std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
   std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::CancelTransition>>
+  client_cancel_transition_;
 };
 
 
@@ -471,6 +496,12 @@ TEST_F(TestLifecycleServiceClientRCLErrors, call_services_rcl_errors) {
 
   // on_get_transition_graph
   lifecycle_client->get_transition_graph();
+  rclcpp::spin_some(lifecycle_client);
+  EXPECT_THROW(
+    rclcpp::spin_some(lifecycle_node->get_node_base_interface()), std::runtime_error);
+
+  // on_cancel_transition
+  lifecycle_client->cancel_transition();
   rclcpp::spin_some(lifecycle_client);
   EXPECT_THROW(
     rclcpp::spin_some(lifecycle_node->get_node_base_interface()), std::runtime_error);

--- a/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
+++ b/rclcpp_lifecycle/test/test_register_custom_callbacks.cpp
@@ -89,6 +89,7 @@ protected:
   // Custom callbacks
 
 public:
+  // Synchronous callbacks
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_custom_configure(const rclcpp_lifecycle::State & previous_state)
   {
@@ -132,9 +133,74 @@ public:
     ++number_of_callbacks;
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
+
+  // Asynchronous callbacks
+  void
+  on_custom_configure_async(
+    const rclcpp_lifecycle::State & previous_state,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_CONFIGURING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  void
+  on_custom_activate_async(
+    const rclcpp_lifecycle::State & previous_state,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_ACTIVATING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  void
+  on_custom_deactivate_async(
+    const rclcpp_lifecycle::State & previous_state,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_ACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_DEACTIVATING, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  void
+  on_custom_cleanup_async(
+    const rclcpp_lifecycle::State & previous_state,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::PRIMARY_STATE_INACTIVE, previous_state.id());
+    EXPECT_EQ(State::TRANSITION_STATE_CLEANINGUP, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
+
+  void
+  on_custom_shutdown_async(
+    const rclcpp_lifecycle::State &,
+    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
+  {
+    EXPECT_EQ(State::TRANSITION_STATE_SHUTTINGDOWN, get_current_state().id());
+    EXPECT_TRUE(change_state_hdl != nullptr);
+    ++number_of_callbacks;
+    change_state_hdl->send_callback_resp(
+      rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS);
+  }
 };
 
-TEST_F(TestRegisterCustomCallbacks, custom_callbacks) {
+TEST_F(TestRegisterCustomCallbacks, custom_synchronous_callbacks) {
   auto test_node = std::make_shared<CustomLifecycleNode>("testnode");
 
   test_node->register_on_configure(
@@ -157,6 +223,52 @@ TEST_F(TestRegisterCustomCallbacks, custom_callbacks) {
     std::bind(
       &CustomLifecycleNode::on_custom_deactivate,
       test_node.get(), std::placeholders::_1));
+
+  EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CONFIGURE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_ACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_ACTIVATE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_INACTIVE, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_DEACTIVATE)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_UNCONFIGURED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_CLEANUP)).id());
+  EXPECT_EQ(
+    State::PRIMARY_STATE_FINALIZED, test_node->trigger_transition(
+      rclcpp_lifecycle::Transition(Transition::TRANSITION_UNCONFIGURED_SHUTDOWN)).id());
+
+  // check if all callbacks were successfully overwritten
+  EXPECT_EQ(5u, test_node->number_of_callbacks);
+}
+
+
+TEST_F(TestRegisterCustomCallbacks, custom_asynchronous_callbacks) {
+  auto test_node = std::make_shared<CustomLifecycleNode>("testnode");
+
+  test_node->register_async_on_configure(
+    std::bind(
+      &CustomLifecycleNode::on_custom_configure_async,
+      test_node.get(), std::placeholders::_1, std::placeholders::_2));
+  test_node->register_async_on_cleanup(
+    std::bind(
+      &CustomLifecycleNode::on_custom_cleanup_async,
+      test_node.get(), std::placeholders::_1, std::placeholders::_2));
+  test_node->register_async_on_shutdown(
+    std::bind(
+      &CustomLifecycleNode::on_custom_shutdown_async,
+      test_node.get(), std::placeholders::_1, std::placeholders::_2));
+  test_node->register_async_on_activate(
+    std::bind(
+      &CustomLifecycleNode::on_custom_activate_async,
+      test_node.get(), std::placeholders::_1, std::placeholders::_2));
+  test_node->register_async_on_deactivate(
+    std::bind(
+      &CustomLifecycleNode::on_custom_deactivate_async,
+      test_node.get(), std::placeholders::_1, std::placeholders::_2));
 
   EXPECT_EQ(State::PRIMARY_STATE_UNCONFIGURED, test_node->get_current_state().id());
   EXPECT_EQ(


### PR DESCRIPTION
## Overview of this PR
> :warning: NOT GOING IN rclcpp PR
> This section outlines the strategy for the PR

This is a draft PR before opening a PR against rclcpp/ros2:rolling. 

The below text is going in the issue. The PR text will link to the issue. Links are removed from the below text as to not reference issues until the final issue/PR are up.

---
## Issue Text

# Asynchronous lifecycle `change_state`

## Feature request
Allow for user transition callbacks within lifecycle nodes (e.g., `on_configure`) to defer work. This would allow for:
1. nodes/entities with external transition dependencies to defer work until those dependencies are met (e.g., requests to external service(s) is/are ready/complete)
2. attempting recovery mid-transition instead of needing to fully shutdown + fully bring the node back to a desired state

## Feature description
Lifecycle transition callbacks currently must be synchronous. With the limitation of calling service within a service PR773 and the advent of async services PR1709, we would like to propose adding the ability to defer work within a user transition callback (e.g., `on_configure`). The `change_state` process would ideally be deferable + cancelleable. This would allow for both long running functions (e.g., a long load in `on_configure`) as well as free up the executor to process new events.

[Demo Repo](https://github.com/tgroechel/lifecycle_prac/tree/defer_cancel_user_transtion_callbacks)

<details>

<summary>Expand for in-line example code</summary>

```cpp
void on_configure_async(
    const rclcpp_lifecycle::State &,
    std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl) {
  // Cancel monitoring
  transition_cancel_monitoring_timer_ = create_wall_timer(
      std::chrono::milliseconds{100}, [this, change_state_hdl]() {
        if (!change_state_hdl->is_executing()) {
          transition_cancel_monitoring_timer_.reset();
          return;
        } else if (change_state_hdl->is_canceling()) { /*handle cancel*/
          size_t num_pruned_req = client_->prune_pending_requests();
          RCLCPP_INFO(this->get_logger(), "Handle cancel: pruned %ld request",
                      num_pruned_req);
          change_state_hdl->handle_canceled(true);
          transition_cancel_monitoring_timer_.reset();
        }
      });

  // Callback for future response of getting a parameter
  auto response_received_callback =
      [logger = this->get_logger(), change_state_hdl](
          rclcpp::Client<rcl_interfaces::srv::GetParameters>::SharedFuture
              future) {
        if (change_state_hdl->is_executing()) {
          auto request_response_pair = future.get();
          RCLCPP_INFO(logger, "Received parameter response: %s",
                      request_response_pair->values[0].string_value.c_str());
          change_state_hdl->send_callback_resp(
              rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
                  CallbackReturn::SUCCESS);
        }
      };

  // Sending the request and attaching the callback
  auto request =
      std::make_shared<rcl_interfaces::srv::GetParameters::Request>();
  request->names.push_back("param1");
  RCLCPP_INFO(this->get_logger(), "Sending async param request");
  client_->async_send_request(request, std::move(response_received_callback));
} // Off executor

void on_activate_async(
  const rclcpp_lifecycle::State & state,
  std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
{
  LifecycleNode::on_activate(
    state);   // activates managed entities (i.e., lifecycle_publishers)
  // create a thread to do some work passing the change_state_hdl to the
  // thread
  std::thread t(&LifecycleTalker::defer_on_activate_work, this,
    change_state_hdl);
  t.detach();
}

void defer_on_activate_work(
  std::shared_ptr<rclcpp_lifecycle::ChangeStateHandler> change_state_hdl)
{
  int sleep_time = 3;
  RCLCPP_INFO(
    this->get_logger(),
    "on_activate() {async} is called, sleeping is separate thread "
    "for %d seconds.",
    sleep_time);
  std::this_thread::sleep_for(std::chrono::seconds{sleep_time});
  RCLCPP_INFO(
    this->get_logger(),
    "on_activate() done sleeping, returning success");
  change_state_hdl->send_callback_resp(
    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
    CallbackReturn::SUCCESS);
}
```

</details>

https://github.com/tgroechel/lifecycle_prac/assets/15292506/55600d76-9cea-40b4-8423-76d81e7e7fbf

The "ideal" would be to turn the `ChangeState.srv` into an `Action` ([docs](https://docs.ros.org/en/foxy/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Actions/Understanding-ROS2-Actions.html)). This would give the robust capability of accept/reject a change request, publish its status, and have the ability to cancel mid transition with user attempt to handle the cancel. However, turning `change_state` into an action would break all backward compatibility (i.e., all lifecycle nodes and clients).

**We propose an initial stage, backward compatible solution here**: PRLINK

Exact details can be found within that PR but to summarize:
- To make current lifecycle dev as well as transitioning to an `Action` in the future easier, we re-architect `LifecycleNodeInterfaceImpl` for a cleaner separation of concerns similar to [model-view-controller](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller):
  - `LifecycleNodeInterfaceImpl`: ("`controller`") owner of:
    - `StateManager`: (`model:lifecycle_state`) responsible for lifecycle `state_machine`
    - `StateServicesManager`: ("`view + controller`") public interface of services
    - `EntitiesManager`: (`model:managed_entities`)responsible for entity state
- Created a `ChangeStateHandler` that acts very similar to a `GoalHandle` within a ROS 2 Action. The example above should give better context for this.
  - `shared_ptr` given to the user transition callback for the user to `send_callback_resp(CallbackReturn)` whenever the transition completes
  - has an equivalent `is_cancelled()` so the user can attempt to handle a cancel mid-transition
  - when a `transition_cancel` succeeds, the state follows the respective `CallbackReturn::FAILURE` path (e.g., `CONFIGURING` -> `handled_cancel(true)` -> `UNCONFIGURED`). 

<details>

<summary>Reference for `Callback::FAILURE` paths of lifecycle nodes</summary>

![image](https://github.com/tgroechel/rclcpp/assets/15292506/b5cd3b62-cbb4-4b9c-8bf7-92d553dc8357)

</details>

We hope this issue can serve as a discussion around the ability to create asynchronous state changes, whether that be through the above suggested approach and/or a long term plan to turn them into `Actions`.

---

## PR Text

# Async Lifecycle `change_state` Implementation

This PR addresses ISSUELINK to enable async/deferrable user transition callbacks (e.g., `on_configure`) within lifecycle nodes. This is a proposed first-stage solution:
- maintains backward compatibility (the core reason for not directly converting to a ROS 2 Action)
- attempts to structure the code to allow for possible future transition to using a [ROS 2 Action](https://docs.ros.org/en/foxy/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Actions/Understanding-ROS2-Actions.html) for `ChangeState`

Dependency: RCL_INTERFACESPRLINK

Demo: DEMOLINK

## Separation of Concerns
The `LifecycleNodeInterfaceImpl` was:
1. managing `ManagedEntities`
3. managing underlying `rcl::state_machine`
4. managing services

<details>

<summary>Separation of concerns / new impl architecture</summary>

![soc_lifecycle](https://github.com/tgroechel/rclcpp/assets/15292506/45b4554c-6b53-4a25-8709-cc6386c37ce4)

</details>

This PR splits these into 3 separate classes as shown in the figure above. This follows more closely to a [model-view-controller](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) design:

`LifecycleNodeInterfaceImpl`: ("`controller`") owner of:
- `EntitiesManager`: (`model:managed_entities`)responsible for entity state
- `StateManager`: (`model:lifecycle_state`) responsible for lifecycle `state_machine`
- `StateServicesManager`: ("`view + controller`") public interface of services


## ChangeStateHandler
An async transition follows the same flow as before but now passes a `ChangeState` handler that:
- allows response deferral
- allows for handling a cancel request
This is very similar to a `GoalHandler` within a ROS 2 Action. However, we want to maintain backward compatibility. 

### Async transition

<details>

<summary>Control flow of an async transition</summary>

![image-20230531-133549](https://github.com/tgroechel/rclcpp/assets/15292506/99537ce2-7d3f-4bd4-aa6b-2c05e5220efd)

</details>

The above image outlines the process. Only 1 request can be processed at a given time, all other requests are rejected. The `ChangeStateHandler` allows for the user to send a response whenever they are done with the transition (accomplished by passing a newly created `shared_ptr<ChangeStateHandler>` to the user).


### Cancelling a transition

<details>

<summary>Reference for `Callback::FAILURE` paths of lifecycle nodes</summary>

![image](https://github.com/tgroechel/rclcpp/assets/15292506/b5cd3b62-cbb4-4b9c-8bf7-92d553dc8357)

</details>

Given that the transition is async, it would be ideal if it could also have the potential to be cancelled. The goal would to attempt to recover the node into a valid primary state. With this:
- only the user can handle a cancel safely so the `ChangeStateHandler` is "marked" as cancelled and waits until the user marks the cancel as completed
- if handled successfully, the state follows a `CallbackReturn::Failure` path. This is desired to
  - recover, mostly, to the last primary state (see reference diagram above)
  - maintain `state_machine` validity/backward compatibility
  - reuse the same code as `change_state`

<details>

<summary>Control flow of an async transition</summary>

![cancel_no_timeout](https://github.com/tgroechel/rclcpp/assets/15292506/5b284a3f-5f00-4372-9e23-41d283499043)

</details>

The example flow of a cancelled transition. Note this is all possible even on a `SingleThreadedExecutor` as the timer acts as a monitor for the transition. Note the rejection and failure criteria / reasons are passed back to the client within the `CancelTransition.srv`.

---

### Additional features that may be added

Features 1 & 2 would be somewhat/theoretically trivial to add given the implementation

1. Ability to directly bind a `handle_cancel` function that is called upon cancel.
2. In the case we are:
    1. in transition
    2. receive a cancel request but we fail to cancel
    3. transition completes
    4. Instead of going to the next state, we **instead treat the mid-transition cancel as a `CallbackReturn::ERROR` and process it as such**
3. [not as trivial] Create a container that can send out a set of requests, creating future callbacks for each. The container would have the ability to them know when all requests have been completed/send the `CallbackReturn` response. The container could also help with handling a cancel request by pruning all waiting request.
